### PR TITLE
Fix enabling linger for systemd

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -124,4 +124,4 @@
 
 - name: enable systemctl services for deploy user
   become: true
-  action: loginctl enable-linger deploy
+  shell: loginctl enable-linger deploy


### PR DESCRIPTION
Use `shell` instead of `action` for `loginctl` commands