### PR TITLE
Lock ami version to avoid accidental updates

### DIFF
--- a/terraform/modules/simple_server/aws_ami.tf
+++ b/terraform/modules/simple_server/aws_ami.tf
@@ -1,6 +1,4 @@
 data "aws_ami" "ubuntu" {
-  most_recent = true
-
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
@@ -9,6 +7,11 @@ data "aws_ami" "ubuntu" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
+  }
+
+  filter {
+    name = "image-id"
+    values = ["ami-0c28d7c6dd94fb3a7"]
   }
 
   owners = ["099720109477"] # Use official Canonical Ubuntu AMIs


### PR DESCRIPTION
If there a newer AMI available, our scripts will currently recreate the EC2 instances. This is very disruptive. To avoid automatically updating the AMI on the EC2 instances, this PR locks the AMI version to the current AMI ID. 