### PR TITLE
Upgrade bangladesh hosts

### DIFF
--- a/ansible/hosts.bangladesh-demo
+++ b/ansible/hosts.bangladesh-demo
@@ -1,6 +1,6 @@
 [simple]
-ec2-13-233-161-111.ap-south-1.compute.amazonaws.com
-ec2-13-126-143-36.ap-south-1.compute.amazonaws.com
+ec2-13-127-62-208.ap-south-1.compute.amazonaws.com
+ec2-3-6-91-15.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/ansible/hosts.bangladesh-production
+++ b/ansible/hosts.bangladesh-production
@@ -1,7 +1,7 @@
 [simple]
-ec2-3-6-38-148.ap-south-1.compute.amazonaws.com
-ec2-13-235-13-52.ap-south-1.compute.amazonaws.com
-ec2-13-232-141-5.ap-south-1.compute.amazonaws.com
+ec2-13-234-38-169.ap-south-1.compute.amazonaws.com
+ec2-13-127-239-96.ap-south-1.compute.amazonaws.com
+ec2-52-66-210-7.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple


### PR DESCRIPTION
Bangladesh hosts had to be upgraded to the the correct AMIs.
This PR upgrades the hosts files with the new addresses. 