### PR TITLE
Increase max request queue size from 100 to 200

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
@@ -32,6 +32,7 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
+  passenger_max_request_queue_size 200;
   passenger_min_instances 1;
   passenger_start_timeout 300;
 


### PR DESCRIPTION
This is an attempt to mitigate issues caused by large-ish patient record payloads taking a long time to process.