### PR TITLE
Tune nginx to consistently launch and maintain 10 workers

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -69,7 +69,8 @@ http {
 	passenger_ruby /home/deploy/.rbenv/shims/ruby;
 
   passenger_max_preloader_idle_time 0;
-  passenger_max_pool_size 3;
+  passenger_max_pool_size 10;
+  passenger_min_instances 10;
   passenger_pool_idle_time 300;
 
 	# passenger_ruby /usr/bin/passenger_free_ruby;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-demo
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-demo
@@ -24,7 +24,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-production
@@ -24,7 +24,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
@@ -33,7 +33,6 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_max_request_queue_size 200;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
@@ -32,7 +32,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-sandbox
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-sandbox
@@ -33,7 +33,6 @@ server {
     passenger_app_root /home/deploy/apps/simple-server/current;
     passenger_enabled on;
     rails_env production;
-    passenger_min_instances 1;
     passenger_start_timeout 300;
 
     gzip on;
@@ -75,7 +74,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-security
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-security
@@ -33,7 +33,6 @@ server {
     passenger_app_root /home/deploy/apps/simple-server/current;
     passenger_enabled on;
     rails_env production;
-    passenger_min_instances 1;
     passenger_start_timeout 300;
 
     gzip on;
@@ -75,7 +74,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-staging
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-staging
@@ -32,7 +32,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;
@@ -74,7 +73,6 @@ server {
   passenger_app_root /home/deploy/apps/simple-server/current;
   passenger_enabled on;
   rails_env production;
-  passenger_min_instances 1;
   passenger_start_timeout 300;
 
   gzip on;


### PR DESCRIPTION
We discovered that our system was wildly out of tune for the EC2 machine sizes we have. In short, each machine was only spinning up at most 3 Passenger workers, and downsizing to 1 in cases of low traffic.

Spinning up Passenger workers is very slow, and we have no reason to conserve resources. I've bumped the max worker size to 10, and made that the minimum as well. This ensures we always have 10 workers around to handle requests.

To set this number, the rule of thumb is: `(MACHINE_RAM * 0.75) / MAX_RAM_PER_PROCESS`

In our case, our max RAM per process hovers around 300MB, so we used 400MB for the calculation. Our production machines have 8GB of RAM, so:

```
(8 * 1024 * 0.75) / 400 = 15.36 workers
```

To be safe, we're setting it to 10 to avoid memory outages.

Note that passenger workers are shared across `server` blocks. This means that if you have two `server` blocks, A and B, and A gets tons of traffic, Passenger will allocate all 10 workers to A. If B gets a request, Passenger will forcefully grab one of the workers from A and queue A until B is done.

See https://www.phusionpassenger.com/library/config/nginx/optimization/