### PR TITLE
NGINX config changes to meet the VAPT requirements (in adherence to OWASP)

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-	# server_tokens off;
+	server_tokens off;
 
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;

--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
 	ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
 	ssl_dhparam /etc/ssl/dhparam.pem;
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.2; # Dropping SSLv3, ref: POODLE
 	ssl_prefer_server_ciphers on;
 	ssl_session_cache shared:SSL:10m;
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2184102/stories/171354820

* Don't use TLSv1, TLSv1.1
* Don't disclose server version from nginx