### PR TITLE
Updated SSL cipher list, turned off TLS 1.0 and server tokens

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -3,104 +3,105 @@ worker_processes 4;
 pid /run/nginx.pid;
 
 events {
-	worker_connections 768;
-	# multi_accept on;
+  worker_connections 768;
+  # multi_accept on;
 }
 
 http {
 
-	##
-	# Basic Settings
-	##
+  ##
+  # Basic Settings
+  ##
 
-	sendfile on;
-	tcp_nopush on;
-	tcp_nodelay on;
-	keepalive_timeout 65;
-	types_hash_max_size 2048;
-	# server_tokens off;
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  server_tokens off;
 
-	# server_names_hash_bucket_size 64;
-	# server_name_in_redirect off;
+  # server_names_hash_bucket_size 64;
+  # server_name_in_redirect off;
 
-	include /etc/nginx/mime.types;
-	default_type application/octet-stream;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
 
-	##
-	# SSL Settings
-	##
+  ##
+  # SSL Settings
+  ##
 
-	ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
-	ssl_dhparam /etc/ssl/dhparam.pem;
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
-	ssl_prefer_server_ciphers on;
-	ssl_session_cache shared:SSL:10m;
+  ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 kEDH+AES128 kEDH+AES256 DES-CBC3-SHA +SHA !aNULL !eNULL !LOW !kECDH !DSS !MD5 !RC4 !EXP !PSK !SRP !CAMELLIA !SEED';
+  ssl_dhparam /etc/ssl/dhparam.pem;
+  ssl_protocols TLSv1.3 TLSv1.2 TLSv1.1;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
 
-	##
-	# Logging Settings
-	##
+  ##
+  # Logging Settings
+  ##
 
-	access_log /var/log/nginx/access.log;
-	error_log /var/log/nginx/error.log;
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
 
-	##
-	# Gzip Settings
-	##
+  ##
+  # Gzip Settings
+  ##
 
-	gzip on;
-	gzip_disable "msie6";
+  gzip on;
+  gzip_disable "msie6";
 
-	# gzip_vary on;
-	# gzip_proxied any;
-	# gzip_comp_level 6;
-	# gzip_buffers 16 8k;
-	# gzip_http_version 1.1;
-	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+  # gzip_vary on;
+  # gzip_proxied any;
+  # gzip_comp_level 6;
+  # gzip_buffers 16 8k;
+  # gzip_http_version 1.1;
+  # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-	##
-	# Phusion Passenger config
-	##
-	# Uncomment it if you installed passenger or passenger-enterprise
-	##
+  ##
+  # Phusion Passenger config
+  ##
+  # Uncomment it if you installed passenger or passenger-enterprise
+  ##
 
-	passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
-	passenger_default_user deploy;
-	passenger_default_group deploy;
-	passenger_ruby /home/deploy/.rbenv/shims/ruby;
+  passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
+  passenger_default_user deploy;
+  passenger_default_group deploy;
+  passenger_ruby /home/deploy/.rbenv/shims/ruby;
 
   passenger_max_preloader_idle_time 0;
   passenger_max_pool_size 10;
   passenger_min_instances 10;
   passenger_pool_idle_time 300;
 
-	# passenger_ruby /usr/bin/passenger_free_ruby;
+  # passenger_ruby /usr/bin/passenger_free_ruby;
 
-	##
-	# Virtual Host Configs
-	##
+  ##
+  # Virtual Host Configs
+  ##
 
-	include /etc/nginx/conf.d/*.conf;
-	include /etc/nginx/sites-enabled/*;
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
 }
 
 
 #mail {
-#	# See sample authentication script at:
-#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+# # See sample authentication script at:
+# # http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
 #
-#	# auth_http localhost/auth.php;
-#	# pop3_capabilities "TOP" "USER";
-#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+# # auth_http localhost/auth.php;
+# # pop3_capabilities "TOP" "USER";
+# # imap_capabilities "IMAP4rev1" "UIDPLUS";
 #
-#	server {
-#		listen     localhost:110;
-#		protocol   pop3;
-#		proxy      on;
-#	}
+# server {
+#   listen     localhost:110;
+#   protocol   pop3;
+#   proxy      on;
+# }
 #
-#	server {
-#		listen     localhost:143;
-#		protocol   imap;
-#		proxy      on;
-#	}
+# server {
+#   listen     localhost:143;
+#   protocol   imap;
+#   proxy      on;
+# }
 #}


### PR DESCRIPTION
To meet CyRAACS requirements, we updated the nginx config to:

- Disable TLS 1.0
- Disable weak ciphers
- Disable displaying the server version in the headers

(I also switched from tabs to spaces, so ignore whitespace changes)