### PR TITLE
Disable server version from both nginx+passenger

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -19,8 +19,7 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
   server_tokens off;
-  more_clear_headers Server;
-  more_clear_headers X-Powered-By;
+  passenger_show_version_in_header off;
 
   # server_names_hash_bucket_size 64;
   # server_name_in_redirect off;

--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -19,7 +19,6 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
   server_tokens off;
-  passenger_show_version_in_header off;
 
   # server_names_hash_bucket_size 64;
   # server_name_in_redirect off;
@@ -74,6 +73,8 @@ http {
   passenger_max_pool_size 10;
   passenger_min_instances 10;
   passenger_pool_idle_time 300;
+
+  passenger_show_version_in_header off;
 
   # passenger_ruby /usr/bin/passenger_free_ruby;
 

--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -19,6 +19,8 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
   server_tokens off;
+  more_clear_headers Server;
+  more_clear_headers X-Powered-By;
 
   # server_names_hash_bucket_size 64;
   # server_name_in_redirect off;


### PR DESCRIPTION
Using this [comment](https://github.com/phusion/passenger/issues/186#issuecomment-314363176) as reference to disable the `X-Powered-By` and `Server` headers from API requests.