### PR TITLE
Update india staging address

### DIFF
--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -1,5 +1,5 @@
 [simple]
-ec2-13-126-48-114.ap-south-1.compute.amazonaws.com
+ec2-13-233-201-228.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple


### PR DESCRIPTION
The India staging server became unresponsive and needed to be restarted. This PR updates the address.