### PR TITLE
standalone: common tasks via make

### DIFF
--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -2,7 +2,7 @@ hosts = icmr/playground
 password_file = ~/.password_file
 export ANSIBLE_CONFIG = ansible/ansible.cfg
 
-.PHONY: help init all update-ssh-keys
+.PHONY: help init all update-ssh-keys restart-passenger restart-sidekiq
 # HELP sourced from https://gist.github.com/prwhite/8168133
 
 # Add help text after each target name starting with '\#\#'
@@ -38,3 +38,6 @@ update-app-config: ##@Utilities Update app config .env file
 
 restart-passenger: ##@Utilities Restart passenger
 	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i hosts/$(hosts) -l webservers --tags restart-passenger
+
+restart-sidekiq: ##@Utilities Restart sidekiq
+	ansible-playbook --vault-id $(password_file) ansible/deploy.yml -i hosts/$(hosts) -l sidekiq --tags restart-sidekiq

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -14,7 +14,7 @@ HELP_FUNC = \
             push(@{$$help{$$2}}, [$$1, $$3]); \
         } \
     }; \
-    print "usage: make [target]\n\n"; \
+    print "usage: make [target] hosts=<icmr/playground>\n\n"; \
     for ( sort keys %help ) { \
         print "$$_:\n"; \
         printf("  %-20s %s\n", $$_->[0], $$_->[1]) for @{$$help{$$_}}; \
@@ -27,8 +27,11 @@ help: ##@Miscellaneous Show this help.
 init: ##@Setup Install ansible plugins
 	ansible-galaxy install -r requirements.yml
 
-all: ##@Setup Install simple-server on hosts. Runs the all.yml playbook.
+all: ##@Setup Install simple-server on hosts. Runs the all.yml playbook
 	ansible-playbook --vault-id $(password_file) ansible/$@.yml -i hosts/$(hosts)
 
-update-ssh-keys: ##@Utilities Update ssh on boxes: make update-ssh-keys hosts=<icmr/playground>
+update-ssh-keys: ##@Utilities Update ssh keys on boxes. Add keys to `ansible/roles/ssh/` under the appropriate environment
 	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i hosts/$(hosts) --tags ssh
+
+update-app-config: ##@Utilities Update app config .env file
+	ansible-playbook --vault-id $(password_file) ansible/deploy.yml -i hosts/$(hosts) --tags update-app-config

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -1,2 +1,9 @@
+inventory_file = hosts/icmr/playground
+password_file = ~/.password_file
+export ANSIBLE_CONFIG = ansible/ansible.cfg
+
 init :
 	ansible-galaxy install -r requirements.yml
+
+update-ssh-keys:
+	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i $(inventory_file) --tags ssh

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -1,9 +1,34 @@
-inventory_file = hosts/icmr/playground
+hosts = icmr/playground
 password_file = ~/.password_file
 export ANSIBLE_CONFIG = ansible/ansible.cfg
 
-init :
+.PHONY: help init all update-ssh-keys
+# HELP sourced from https://gist.github.com/prwhite/8168133
+
+# Add help text after each target name starting with '\#\#'
+# A category can be added with @category
+HELP_FUNC = \
+    %help; \
+    while(<>) { \
+        if(/^([a-z0-9_-]+):.*\#\#(?:@(\w+))?\s(.*)$$/) { \
+            push(@{$$help{$$2}}, [$$1, $$3]); \
+        } \
+    }; \
+    print "usage: make [target]\n\n"; \
+    for ( sort keys %help ) { \
+        print "$$_:\n"; \
+        printf("  %-20s %s\n", $$_->[0], $$_->[1]) for @{$$help{$$_}}; \
+        print "\n"; \
+    }
+
+help: ##@Miscellaneous Show this help.
+	@perl -e '$(HELP_FUNC)' $(MAKEFILE_LIST)
+
+init: ##@Setup Install ansible plugins
 	ansible-galaxy install -r requirements.yml
 
-update-ssh-keys:
-	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i $(inventory_file) --tags ssh
+all: ##@Setup Install simple-server on hosts. Runs the all.yml playbook.
+	ansible-playbook --vault-id $(password_file) ansible/$@.yml -i hosts/$(hosts)
+
+update-ssh-keys: ##@Utilities Update ssh on boxes: make update-ssh-keys hosts=<icmr/playground>
+	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i hosts/$(hosts) --tags ssh

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -35,3 +35,6 @@ update-ssh-keys: ##@Utilities Update ssh keys on boxes. Add keys to `ansible/rol
 
 update-app-config: ##@Utilities Update app config .env file
 	ansible-playbook --vault-id $(password_file) ansible/deploy.yml -i hosts/$(hosts) --tags update-app-config
+
+restart-passenger: ##@Utilities Restart passenger
+	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i hosts/$(hosts) -l webservers --tags restart-passenger

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -25,7 +25,7 @@ help: ##@Miscellaneous Show this help.
 	@perl -e '$(HELP_FUNC)' $(MAKEFILE_LIST)
 
 init: ##@Setup Install ansible plugins
-	ansible-galaxy install -r requirements.yml
+	ansible-galaxy install -r ansible/requirements.yml
 
 all: ##@Setup Install simple-server on hosts. Runs the all.yml playbook
 	ansible-playbook --vault-id $(password_file) ansible/$@.yml -i hosts/$(hosts)

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -52,6 +52,7 @@ These instructions are to be followed in the `standalone` directory of this repo
 - Set the following in the `hosts/icmr/playground` Ansible inventory file
     - Set `domain_name` to your domain name (eg. `playground.simple.org`)
     - Set `deploy_env` to your desired environment name (eg. `staging`, `production`, `sandbox`)
+- Run `make`
 - Run `ansible-playbook --vault-id <path/to/password_file> all.yml -i ../hosts/icmr/playground`
     - Simple server should now be installed, running and accessible on your domain.
 
@@ -108,3 +109,10 @@ for development. You can view or edit the contents of these vault files directly
 ansible-vault view --vault-id ../../password_file roles/passenger/vars/ssl-vault.yml
 ansible-vault edit --vault-id ../../password_file roles/passenger/vars/ssl-vault.yml
 ```
+
+### Updating ssh keys
+Add keys to `ansible/roles/ssh/` under the appropriate environment.
+```bash
+make update-ssh-keys
+```
+Note that this clears any old keys present on the servers.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -123,3 +123,15 @@ Variables are sourced from `ansible/roles/deploy/templates/vars`
 ```bash
 make update-app-config hosts=icmr/playground
 ```
+
+### Restarting passenger
+```bash
+make restart-passenger hosts=icmr/playground
+```
+Note that this restarts passenger on all servers.
+
+### Restarting sidekiq
+```bash
+make restart-sidekiq hosts=icmr/playground
+```
+

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -52,8 +52,8 @@ These instructions are to be followed in the `standalone` directory of this repo
 - Set the following in the `hosts/icmr/playground` Ansible inventory file
     - Set `domain_name` to your domain name (eg. `playground.simple.org`)
     - Set `deploy_env` to your desired environment name (eg. `staging`, `production`, `sandbox`)
-- Run `make`
-- Run `ansible-playbook --vault-id <path/to/password_file> all.yml -i ../hosts/icmr/playground`
+- Run `make init`
+- Run `make all` to setup simple-server on your servers.
     - Simple server should now be installed, running and accessible on your domain.
 
 ## Provisioning Testing Servers
@@ -113,6 +113,6 @@ ansible-vault edit --vault-id ../../password_file roles/passenger/vars/ssl-vault
 ### Updating ssh keys
 Add keys to `ansible/roles/ssh/` under the appropriate environment.
 ```bash
-make update-ssh-keys
+make update-ssh-keys hosts=icmr/playground
 ```
 Note that this clears any old keys present on the servers.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -116,3 +116,10 @@ Add keys to `ansible/roles/ssh/` under the appropriate environment.
 make update-ssh-keys hosts=icmr/playground
 ```
 Note that this clears any old keys present on the servers.
+
+### Updating app config
+The app's .env file sits in `ansible/roles/deploy/templates/.env.j2`.
+Variables are sourced from `ansible/roles/deploy/templates/vars`
+```bash
+make update-app-config hosts=icmr/playground
+```

--- a/standalone/ansible/group_vars/servers.yml
+++ b/standalone/ansible/group_vars/servers.yml
@@ -21,6 +21,6 @@ logrotate_dir: "{{ ansistrano_deploy_to }}/current/log"
 logrotate_files: "{{ logrotate_dir }}/*.log"
 logrotate_config_file: "/etc/logrotate.d/rails"
 
-rsync_dir: "log_dir/*.gz"
+rsync_dir: "{{ logrotate_dir }}/*.gz"
 rsync_logfile: "{{ logrotate_dir }}/rsync.log"
 rsync_destination_dir: "/home/{{ deploy_user }}/logs/rails"

--- a/standalone/ansible/group_vars/servers.yml
+++ b/standalone/ansible/group_vars/servers.yml
@@ -18,7 +18,7 @@ postgres:
 
 logrotate_user: "{{ deploy_user }}"
 logrotate_dir: "{{ ansistrano_deploy_to }}/current/log"
-logrotate_files: "{{ log_dir }}/*.log"
+logrotate_files: "{{ logrotate_dir }}/*.log"
 logrotate_config_file: "/etc/logrotate.d/rails"
 
 rsync_dir: "log_dir/*.gz"

--- a/standalone/ansible/requirements.yml
+++ b/standalone/ansible/requirements.yml
@@ -1,8 +1,7 @@
-roles:
-  - src: ansistrano.deploy
-  - src: ansistrano.rollback
-  - src: cloudalchemy.prometheus
-  - src: cloudalchemy.grafana
-  - src: cloudalchemy.node-exporter
-  - src: davidwittman.redis
-  - src: geerlingguy.haproxy
+---
+- src: ansistrano.deploy
+- src: ansistrano.rollback
+- src: cloudalchemy.prometheus
+- src: cloudalchemy.grafana
+- src: cloudalchemy.node-exporter
+- src: davidwittman.redis

--- a/standalone/ansible/roles/deploy/tasks/main.yml
+++ b/standalone/ansible/roles/deploy/tasks/main.yml
@@ -4,11 +4,13 @@
   include_vars:
     file: "{{ deploy_env }}/feature_flags.yml"
     name: feature_flags
+  tags: update-app-config
 
 - name: Deploy | Include secrets
   include_vars:
     file: "{{ deploy_env }}/secrets.yml"
     name: secrets
+  tags: update-app-config
 
 - name: Deploy | Create apps directory
   file:
@@ -20,3 +22,4 @@
   template:
     src: .env.j2 
     dest: /home/deploy/apps/{{app_name}}/shared/.env.production
+  tags: update-app-config

--- a/standalone/ansible/roles/passenger/tasks/main.yml
+++ b/standalone/ansible/roles/passenger/tasks/main.yml
@@ -65,7 +65,12 @@
     src: /etc/nginx/sites-available/{{ domain_name }}
     dest: /etc/nginx/sites-enabled/{{ domain_name }}
   become: true
+
+- name: restart nginx
+  become: true
+  command: /bin/true
   notify: restart nginx
+  tags: restart-passenger
 
 - name: enable monit for nginx
   file: >

--- a/standalone/ansible/roles/sidekiq/tasks/main.yml
+++ b/standalone/ansible/roles/sidekiq/tasks/main.yml
@@ -16,3 +16,9 @@
 
 - name: Sidekiq | reload monit
   shell: monit reload
+
+- name: Sidekiq | restart sidekiq
+  monit:
+    name: "{{ sidekiq_service_name }}"
+    state: restarted
+  tags: restart-sidekiq


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171896981

## Because

Some commonly performed tasks are slightly tedious to run via ansible. We need an abstraction over ansible that makes these less painful. This will also make handing over maintenance to a third party easier.

## This addresses

This adds a makefile with recipes for common actions:
- Adding/removing ssh keys
- Updating app config
- Restart Passenger
- Restart Sidekiq

Bonus recipes:
- Setting up `simple-server`