### PR TITLE
standalone: postgres hot standby

### DIFF
--- a/standalone/ansible/group_vars/postgres.yml
+++ b/standalone/ansible/group_vars/postgres.yml
@@ -7,9 +7,9 @@ postgres:
     - {contype: host,  databases: all, users: all, source: all, method: md5}
     - {contype: local, databases: all, users: all, source: all, method: md5}
 
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 
 ansible_python_interpreter: /usr/bin/python3
 

--- a/standalone/ansible/postgres.yml
+++ b/standalone/ansible/postgres.yml
@@ -2,3 +2,4 @@
 - hosts: postgres
   roles:
     - { role: postgres, tags: ['postgres'] }
+    - { role: postgres_replication, tags: ['postgres_replication'] }

--- a/standalone/ansible/roles/postgres_replication/meta/main.yml
+++ b/standalone/ansible/roles/postgres_replication/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: postgres }

--- a/standalone/ansible/roles/postgres_replication/tasks/main.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- include_tasks: "{{ replication_role }}.yml"
+
+- name: Restart postgresql
+  service:
+    name: "{{ postgresql_daemon }}"
+    state: restarted

--- a/standalone/ansible/roles/postgres_replication/tasks/master.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/master.yml
@@ -1,0 +1,33 @@
+---
+- name: Master | create replication user account
+  postgresql_user:
+    name: "{{ replication_user }}"
+    role_attr_flags: replication
+  become: yes
+  become_user: postgres
+
+- name: Master | grant permissions for standby db to replicate
+  postgresql_pg_hba:
+    dest: "{{ postgresql_config_path }}/pg_hba.conf"
+    contype: "host"
+    users: "{{ replication_user }}"
+    source: "{{ item }}/32"
+    databases: "replication"
+    method: "trust"
+    create: true
+    backup: true
+  register: postgres_hba_conf
+  with_items: "{{ groups.postgres_secondary }}"
+
+- name: Master | set postgresql.conf replication settings on master
+  lineinfile:
+    state: present
+    dest: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: "{{ item.regex }}"
+    line: "{{ item.name }}={{ item.value }}"
+  with_items: "{{ replication_config }}"
+
+- name: Master | reload postgresql
+  service:
+    name: "{{ postgresql_daemon }}"
+    state: reloaded

--- a/standalone/ansible/roles/postgres_replication/tasks/master.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/master.yml
@@ -19,13 +19,13 @@
   register: postgres_hba_conf
   with_items: "{{ groups.postgres_secondary }}"
 
-- name: Master | set postgresql.conf replication settings on master
+- name: Master | set postgresql.conf replication settings
   lineinfile:
     state: present
     dest: "{{ postgresql_config_path }}/postgresql.conf"
     regexp: "{{ item.regex }}"
     line: "{{ item.name }}={{ item.value }}"
-  with_items: "{{ replication_config }}"
+  with_items: "{{ replication_config_master }}"
 
 - name: Master | reload postgresql
   service:

--- a/standalone/ansible/roles/postgres_replication/tasks/primary.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/primary.yml
@@ -1,12 +1,12 @@
 ---
-- name: Master | create replication user account
+- name: Primary | create replication user account
   postgresql_user:
     name: "{{ replication_user }}"
     role_attr_flags: replication
   become: yes
   become_user: postgres
 
-- name: Master | grant permissions for standby db to replicate
+- name: Primary | grant permissions for standby db to replicate
   postgresql_pg_hba:
     dest: "{{ postgresql_config_path }}/pg_hba.conf"
     contype: "host"
@@ -19,15 +19,15 @@
   register: postgres_hba_conf
   with_items: "{{ groups.postgres_secondary }}"
 
-- name: Master | set postgresql.conf replication settings
+- name: Primary | set postgresql.conf replication settings
   lineinfile:
     state: present
     dest: "{{ postgresql_config_path }}/postgresql.conf"
     regexp: "{{ item.regex }}"
     line: "{{ item.name }}={{ item.value }}"
-  with_items: "{{ replication_config_master }}"
+  with_items: "{{ replication_config_primary }}"
 
-- name: Master | reload postgresql
+- name: Primary | reload postgresql
   service:
     name: "{{ postgresql_daemon }}"
     state: reloaded

--- a/standalone/ansible/roles/postgres_replication/tasks/replica.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/replica.yml
@@ -22,16 +22,13 @@
   become: true
   become_user: postgres
 
-- name: Replica | enable hot standby
+- name: Replica | set postgresql.conf replication settings
   lineinfile:
     state: present
-    backup: yes
-    dest: "{{ postgresql_config_path }}/pg_hba.conf"
-    regexp: '^#?hot_standby = \w+(\s+#.*)'
-    line: 'hot_standby = on\1'
-    backrefs: yes
-  become: yes
-  become_user: postgres
+    dest: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: "{{ item.regex }}"
+    line: "{{ item.name }}={{ item.value }}"
+  with_items: "{{ replication_config_replica }}"
 
 - name: Replica | reload postgresql
   service:

--- a/standalone/ansible/roles/postgres_replication/tasks/replica.yml
+++ b/standalone/ansible/roles/postgres_replication/tasks/replica.yml
@@ -1,0 +1,39 @@
+---
+- name: Replica | stop PostgreSQL
+  service:
+    name: "{{ postgresql_daemon }}"
+    state: stopped
+
+- name: Replica | clear out data directory
+  file:
+    path: "{{ postgresql_data_dir }}"
+    state: absent
+
+- name: Replica | create empty data directory
+  file:
+    path: "{{ postgresql_data_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0700'
+
+- name: Replica | do an initial pg_basebackup and auto-generate recovery.conf
+  shell: pg_basebackup -h {{ groups.postgres_primary[0] }} -U {{ replication_user }} -p 5432 -D {{ postgresql_data_dir }} -P -Xs -R
+  become: true
+  become_user: postgres
+
+- name: Replica | enable hot standby
+  lineinfile:
+    state: present
+    backup: yes
+    dest: "{{ postgresql_config_path }}/pg_hba.conf"
+    regexp: '^#?hot_standby = \w+(\s+#.*)'
+    line: 'hot_standby = on\1'
+    backrefs: yes
+  become: yes
+  become_user: postgres
+
+- name: Replica | reload postgresql
+  service:
+    name: "{{ postgresql_daemon }}"
+    state: reloaded

--- a/standalone/ansible/roles/postgres_replication/vars/main.yml
+++ b/standalone/ansible/roles/postgres_replication/vars/main.yml
@@ -1,0 +1,6 @@
+---
+replication_user: replicator
+replication_config:
+  - {name: wal_level, value: replica, regex: '#?wal_level = \w+(\s+#.*)'}
+  - {name: max_wal_senders, value: 3, regex: '#?max_wal_senders = \d+(\s+#.*)'}
+  - {name: wal_keep_segments, value: 64, regex: '#?wal_keep_segments = .*(\s+#.*)'}

--- a/standalone/ansible/roles/postgres_replication/vars/main.yml
+++ b/standalone/ansible/roles/postgres_replication/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 replication_user: replicator
-replication_config_master:
+replication_config_primary:
   - {name: wal_level, value: replica, regex: '#?wal_level = \w+(\s+#.*)'}
   - {name: max_wal_senders, value: 3, regex: '#?max_wal_senders = \d+(\s+#.*)'}
   - {name: wal_keep_segments, value: 64, regex: '#?wal_keep_segments = .*(\s+#.*)'}

--- a/standalone/ansible/roles/postgres_replication/vars/main.yml
+++ b/standalone/ansible/roles/postgres_replication/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 replication_user: replicator
-replication_config:
+replication_config_master:
   - {name: wal_level, value: replica, regex: '#?wal_level = \w+(\s+#.*)'}
   - {name: max_wal_senders, value: 3, regex: '#?max_wal_senders = \d+(\s+#.*)'}
   - {name: wal_keep_segments, value: 64, regex: '#?wal_keep_segments = .*(\s+#.*)'}
+replication_config_replica:
+  - {name: hot_standby, value: on, regex: '^#?hot_standby = \w+(\s+#.*)'}

--- a/standalone/hosts/icmr/playground
+++ b/standalone/hosts/icmr/playground
@@ -7,7 +7,7 @@ postgres_primary
 postgres_secondary
 
 [postgres_primary]
-139.59.72.135 replication_role=master
+139.59.72.135 replication_role=primary
 
 [postgres_secondary]
 167.71.238.109 replication_role=replica

--- a/standalone/hosts/icmr/playground
+++ b/standalone/hosts/icmr/playground
@@ -7,10 +7,10 @@ postgres_primary
 postgres_secondary
 
 [postgres_primary]
-139.59.78.94
+139.59.72.135 replication_role=master
 
 [postgres_secondary]
-139.59.61.76
+167.71.238.109 replication_role=replica
 
 [servers:children]
 webservers


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171380384

## Because

We need a replica of the primary db in the standalone setup.

## This addresses

This sets up the `postgres_secondary` host to be a hot standby of the primary DB using postgres' [streaming replication](https://www.postgresql.org/docs/9.2/warm-standby.html#STREAMING-REPLICATION).