### PR TITLE
Remove TLS 1.1 from supported SSL protocols

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
   ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 kEDH+AES128 kEDH+AES256 DES-CBC3-SHA +SHA !aNULL !eNULL !LOW !kECDH !DSS !MD5 !RC4 !EXP !PSK !SRP !CAMELLIA !SEED';
   ssl_dhparam /etc/ssl/dhparam.pem;
-  ssl_protocols TLSv1.3 TLSv1.2 TLSv1.1;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;

--- a/terraform/modules/simple_networking/proxy.tf
+++ b/terraform/modules/simple_networking/proxy.tf
@@ -38,7 +38,7 @@ resource "aws_alb_listener" "simple_listener_https" {
   load_balancer_arn = aws_alb.simple_env_proxy.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn   = aws_acm_certificate.cert.arn
 
   default_action {


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171813218

## Because

Our security audit revealed that we are using several insecure ciphers in our TLS 1.1 configuration.

## This addresses

Rather than playing cipher whack-a-mole, we are disabling TLS 1.1 support wholesale. We are doing so because:
* TLS 1.1 itself is deprecated, according to tools/orgs like [testssl.sh](https://testssl.sh/) and `Qualys SSL Labs`.
* These tools have also indicated that TLS 1.2 is supported in a _wide_ range of browsers now (full list incoming)
* The mobile app is locked to using TLS 1.3 or TLS 1.2, and we can gain confidence that dashboard users will be unaffected by doing a 1-day trial of disabling TLS 1.1. This will not interfere with immediate patient care.
