### PR TITLE
Add new sidekiq box for the sandbox env

### DIFF
--- a/ansible/hosts.sandbox
+++ b/ansible/hosts.sandbox
@@ -1,5 +1,6 @@
 [simple]
 ec2-13-235-33-14.ap-south-1.compute.amazonaws.com
+ec2-15-206-123-187.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -106,6 +106,7 @@ module "simple_server_sandbox" {
   database_subnet_group_name = module.simple_networking.database_subnet_group_name
   ec2_instance_type          = "t2.2xlarge"
   server_count               = 1
+  sidekiq_server_count       = 1
   database_username          = var.sandbox_database_username
   database_password          = var.sandbox_database_password
   instance_security_groups   = module.simple_networking.instance_security_groups


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171810658

## Because

The sandbox env runs sidekiq on the same box as the webserver. This can potentially hide problems in other environments where sidekiq on a separate box, and doesn't have access to the same environment as the webserver box. 

## This addresses

This PR along with the related [server PR](https://github.com/simpledotorg/simple-server/pull/867) adds a separate sidekiq box for the sandbox environment so we can catch problems of this type in the sandbox environment.
