### PR TITLE
standalone: backup db dumps

### DIFF
--- a/standalone/ansible/group_vars/postgres.yml
+++ b/standalone/ansible/group_vars/postgres.yml
@@ -22,7 +22,6 @@ rsync_dir: "{{ logrotate_dir }}/*.gz"
 rsync_logfile: "{{ logrotate_dir }}/rsync.log"
 rsync_destination_dir: "/home/{{ deploy_user }}/logs/postgres"
 
-backups_dir: "~/backups"
-backup_files: "~/backups/*.sql"
+backups_dir: "backups/"
 backups_destination_dir: "/home/{{ deploy_user }}/backups/postgres"
 backups_days_to_keep: 30

--- a/standalone/ansible/group_vars/postgres.yml
+++ b/standalone/ansible/group_vars/postgres.yml
@@ -21,3 +21,8 @@ logrotate_config_file: "/etc/logrotate.d/postgres"
 rsync_dir: "{{ logrotate_dir }}/*.gz"
 rsync_logfile: "{{ logrotate_dir }}/rsync.log"
 rsync_destination_dir: "/home/{{ deploy_user }}/logs/postgres"
+
+backups_dir: "~/backups"
+backup_files: "~/backups/*.sql"
+backups_destination_dir: "/home/{{ deploy_user }}/backups/postgres"
+backups_days_to_keep: 30

--- a/standalone/ansible/roles/postgres/tasks/main.yml
+++ b/standalone/ansible/roles/postgres/tasks/main.yml
@@ -122,26 +122,28 @@
 - name: copy .pgpass file
   template:
     src: .pgpass
-    dest: /home/{{ deploy_user }}/.pgpass
+    dest: ~/.pgpass
     mode: 0600
-  become_user: "{{ deploy_user }}"
-  become: true
 
 - name: copy backup dump script
   template:
     src: pg_backup.sh
-    dest: /home/{{ deploy_user }}/pg_backup.sh
+    dest: pg_backup.sh
     mode: +x
-  become_user: "{{ deploy_user }}"
-  become: true
 
-- name: setup cron job to generate backups
+- name: create backups directory on storage
+  file:
+    path: "{{ backups_destination_dir }}"
+    state: directory
+  become: true
+  become_user: "{{ deploy_user }}"
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups.storage }}"
+
+- name: setup cron job to generate backups (and ship if storage host exists)
   cron:
     name: "postgres backup"
     minute: "0"
     hour: "0"
-    job: "/home/{{ deploy_user }}/pg_backup.sh"
-  become_user: "{{ deploy_user }}"
-  become: true
-
-#TODO: setup logrotate
+    job: "./pg_backup.sh"

--- a/standalone/ansible/roles/postgres/tasks/main.yml
+++ b/standalone/ansible/roles/postgres/tasks/main.yml
@@ -118,3 +118,30 @@
     name: "{{ postgresql_daemon }}"
     state: reloaded
   when: postgres_hba_conf.changed
+
+- name: copy .pgpass file
+  template:
+    src: .pgpass
+    dest: /home/{{ deploy_user }}/.pgpass
+    mode: 0600
+  become_user: "{{ deploy_user }}"
+  become: true
+
+- name: copy backup dump script
+  template:
+    src: pg_backup.sh
+    dest: /home/{{ deploy_user }}/pg_backup.sh
+    mode: +x
+  become_user: "{{ deploy_user }}"
+  become: true
+
+- name: setup cron job to generate backups
+  cron:
+    name: "postgres backup"
+    minute: "0"
+    hour: "0"
+    job: "/home/{{ deploy_user }}/pg_backup.sh"
+  become_user: "{{ deploy_user }}"
+  become: true
+
+#TODO: setup logrotate

--- a/standalone/ansible/roles/postgres/tasks/main.yml
+++ b/standalone/ansible/roles/postgres/tasks/main.yml
@@ -1,42 +1,42 @@
 ---
-- name: Postgres | Include secrets
+- name: Include secrets
   include_vars:
     file: "../deploy/vars/{{ deploy_env }}/secrets.yml"
     name: secrets
 
-- name: Postgres | Define postgresql version
+- name: Define postgresql version
   set_fact:
     postgresql_version: "10"
   when: postgresql_version is not defined
 
-- name: Postgres | Define postgresql_daemon.
+- name: Define postgresql_daemon.
   set_fact:
     postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
   when: postgresql_daemon is not defined
 
-- name: Postgres | ensure apt-transport-https is installed
+- name: ensure apt-transport-https is installed
   apt: name=apt-transport-https state=present
   become: true
 
-- name: Postgres | add postgresql apt key
+- name: add postgresql apt key
   apt_key:
     url:  https://www.postgresql.org/media/keys/ACCC4CF8.asc
     state: present
   become: true
 
-- name: Postgres | add postgresql repositories
+- name: add postgresql repositories
   apt_repository:
     repo: "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main"
     state: present
   register: postgres_repo
   become: true
 
-- name: Postgres | update apt cache if repo was added
+- name: update apt cache if repo was added
   apt: update_cache=yes
   when: postgres_repo.changed
   become: true
 
-- name: Postgres | Ensure PostgreSQL 10 dependencies are installed.
+- name: Ensure PostgreSQL 10 dependencies are installed.
   apt:
     pkg:
       - python3-psycopg2
@@ -45,7 +45,7 @@
     state: present
   become: true
 
-- name: Postgres | Ensure PostgreSQL 10 packages are installed.
+- name: Ensure PostgreSQL 10 packages are installed.
   apt:
     pkg:
       - postgresql-10
@@ -53,13 +53,13 @@
     state: present
   become: true
 
-- name: Postgres | Ensure all configured locales are present.
+- name: Ensure all configured locales are present.
   locale_gen:
     name: "{{ postgres.locale }}"
     state: present
   register: locale_gen_result
 
-- name: Postgres | Grant the default permisions for pg_hba conf.
+- name: Grant the default permisions for pg_hba conf.
   with_items: "{{ postgres.pg_hba }}"
   postgresql_pg_hba:
     dest: "/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf"
@@ -74,20 +74,20 @@
   become: true
   become_user: postgres
 
-- name: Postgres | Force-restart PostgreSQL after new locales are generated.
+- name: Force-restart PostgreSQL after new locales are generated.
   service:
     name: "{{ postgresql_daemon }}"
     state: restarted
   when: locale_gen_result.changed
   become: true
 
-- name: Postgres | Create Postgresql database
+- name: Create Postgresql database
   postgresql_db:
     name: "{{ postgres.database_name }}"
   become: yes
   become_user: postgres
 
-- name: Postgres | Create Postgresql user
+- name: Create Postgresql user
   postgresql_user:
     name: "{{ secrets.postgres.username }}"
     password: "{{ secrets.postgres.password }}"
@@ -98,7 +98,7 @@
   become: true
   become_user: postgres
 
-- name: Postgres | Allow postgres to accept all connections
+- name: Allow postgres to accept all connections
   postgresql_set:
     name: listen_addresses
     value: "*"
@@ -106,14 +106,14 @@
   become: true
   become_user: postgres
 
-- name: Postgres | Restart postgresql
+- name: Restart postgresql
   service:
     name: "{{ postgresql_daemon }}"
     state: restarted
   when: postgres_listen_addresses.changed
   become: true
 
-- name: Postgres | Reload postgresql
+- name: Reload postgresql
   service:
     name: "{{ postgresql_daemon }}"
     state: reloaded
@@ -138,8 +138,7 @@
   become: true
   become_user: "{{ deploy_user }}"
   delegate_to: "{{ item }}"
-  with_items:
-    - "{{ groups.storage }}"
+  with_items: "{{ groups.storage }}"
 
 - name: setup cron job to generate backups (and ship if storage host exists)
   cron:

--- a/standalone/ansible/roles/postgres/templates/.pgpass
+++ b/standalone/ansible/roles/postgres/templates/.pgpass
@@ -1,0 +1,1 @@
+localhost:5432:{{ postgres.database_name }}:{{ secrets.postgres.username }}:{{ secrets.postgres.password }}

--- a/standalone/ansible/roles/postgres/templates/pg_backup.sh
+++ b/standalone/ansible/roles/postgres/templates/pg_backup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BACKUP_DIR="/home/deploy/backups"
+FILENAME=$BACKUP_DIR"/`date +\%Y-\%m-\%d`"
+
+if ! mkdir -p $BACKUP_DIR; then
+    echo "Cannot create backup directory in $FINAL_BACKUP_DIR. Go and fix it!" 1>&2
+    exit 1;
+fi;
+
+if ! pg_dump -U {{ secrets.postgres.username }} {{ postgres.database_name }} | gzip > "$FILENAME".sql.gz.in_progress; then
+    echo "[!!ERROR!!] Failed to produce backup database {{ postgres.database_name }}" 1>&2
+else
+    mv "$FILENAME".sql.gz.in_progress "$FILENAME".sql.gz
+fi

--- a/standalone/ansible/roles/postgres/templates/pg_backup.sh
+++ b/standalone/ansible/roles/postgres/templates/pg_backup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-BACKUP_DIR="backups"
-FILENAME=$BACKUP_DIR"/`date +\%Y-\%m-\%d`"
+BACKUP_DIR={{ backups_dir }}
+FILENAME=$BACKUP_DIR"`date +\%Y-\%m-\%d`"
 HOSTNAME=`hostname`
 DAYS_TO_KEEP={{ backups_days_to_keep }}
 
 if ! mkdir -p $BACKUP_DIR; then
-    echo "Cannot create backup directory in $FINAL_BACKUP_DIR. Go and fix it!" 1>&2
+    echo "Cannot create backup directory in $BACKUP_DIR. Go and fix it!" 1>&2
     exit 1;
 fi;
 
@@ -15,7 +15,7 @@ if ! pg_dump -U {{ secrets.postgres.username }} {{ postgres.database_name }} | g
 else
     mv "$FILENAME".sql.gz.in_progress "$FILENAME".sql.gz
   {% for server in groups.storage %}
-    rsync -a {{ backups_dir }}/*.gz {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/
+    rsync -a "$BACKUP_DIR"*.gz {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/
   {% endfor %}
 fi
 


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171380419

## Because

In addition to a hot standby, we need historical backups as well on the standalone setup. These also need to persisted to a separate storage server.

## This addresses

This adds a simple cron job to make postgres DB dumps and ship them to the storage server. Dumps from the last 30 days are preserved on the DB host and storage.
