### PR TITLE
Support single standalone host

### DIFF
--- a/standalone/ansible/group_vars/all.yml
+++ b/standalone/ansible/group_vars/all.yml
@@ -8,3 +8,4 @@ app_name: "simple-server"
 rbenv_root: "/home/{{ deploy_user }}/.rbenv"
 bundle_path: "{{ rbenv_root }}/shims/bundle"
 aws_deploy: false
+database_name: "{{ deploy_env }}-{{ app_name }}-db"

--- a/standalone/ansible/group_vars/all.yml
+++ b/standalone/ansible/group_vars/all.yml
@@ -9,3 +9,4 @@ rbenv_root: "/home/{{ deploy_user }}/.rbenv"
 bundle_path: "{{ rbenv_root }}/shims/bundle"
 aws_deploy: false
 database_name: "{{ deploy_env }}-{{ app_name }}-db"
+nginx_port: 8008  # Use 8008 (HTTP Alternate) to avoid conflict with HAProxy in case deployment is on a single box

--- a/standalone/ansible/group_vars/postgres.yml
+++ b/standalone/ansible/group_vars/postgres.yml
@@ -1,7 +1,7 @@
 ---
 postgres:
   locale: "en_US.UTF-8"
-  database_name: "{{ deploy_env }}-{{ app_name }}-db"
+  database_name: "{{ database_name }}"
   pg_hba:
     - {contype: local, databases: all, users: postgres, method: peer}
     - {contype: host,  databases: all, users: all, source: all, method: md5}

--- a/standalone/ansible/group_vars/servers.yml
+++ b/standalone/ansible/group_vars/servers.yml
@@ -13,8 +13,8 @@ ansistrano_deploy_via: "git"
 ansistrano_allow_anonymous_stats: no
 ansistrano_git_repo: "https://github.com/simpledotorg/simple-server.git"
 ansistrano_after_symlink_shared_tasks_file: "roles/deploy/hooks/after_symlink.yml"
-postgres:
-  database_name: "{{ deploy_env }}-{{ app_name }}-db"
+
+database_name: "{{ deploy_env }}-{{ app_name }}-db"
 
 logrotate_user: "{{ deploy_user }}"
 logrotate_dir: "{{ ansistrano_deploy_to }}/current/log"

--- a/standalone/ansible/group_vars/servers.yml
+++ b/standalone/ansible/group_vars/servers.yml
@@ -14,8 +14,6 @@ ansistrano_allow_anonymous_stats: no
 ansistrano_git_repo: "https://github.com/simpledotorg/simple-server.git"
 ansistrano_after_symlink_shared_tasks_file: "roles/deploy/hooks/after_symlink.yml"
 
-database_name: "{{ deploy_env }}-{{ app_name }}-db"
-
 logrotate_user: "{{ deploy_user }}"
 logrotate_dir: "{{ ansistrano_deploy_to }}/current/log"
 logrotate_files: "{{ logrotate_dir }}/*.log"

--- a/standalone/ansible/group_vars/webservers.yml
+++ b/standalone/ansible/group_vars/webservers.yml
@@ -1,4 +1,3 @@
-nginx_port: 8008  # Use 8008 (HTTP Alternate) to avoid conflict with HAProxy in case deployment is on a single box
 nginx_stats_port: 8080
 nginx_exporter_options:
   - "-nginx.scrape-uri=http://localhost:{{ nginx_stats_port }}/stub_status"

--- a/standalone/ansible/group_vars/webservers.yml
+++ b/standalone/ansible/group_vars/webservers.yml
@@ -1,3 +1,4 @@
+nginx_port: 80
 nginx_stats_port: 8080
 nginx_exporter_options:
   - "-nginx.scrape-uri=http://localhost:{{ nginx_stats_port }}/stub_status"

--- a/standalone/ansible/group_vars/webservers.yml
+++ b/standalone/ansible/group_vars/webservers.yml
@@ -1,4 +1,4 @@
-nginx_port: 80
+nginx_port: 8008  # Use 8008 (HTTP Alternate) to avoid conflict with HAProxy in case deployment is on a single box
 nginx_stats_port: 8080
 nginx_exporter_options:
   - "-nginx.scrape-uri=http://localhost:{{ nginx_stats_port }}/stub_status"

--- a/standalone/ansible/roles/deploy/templates/.env.j2
+++ b/standalone/ansible/roles/deploy/templates/.env.j2
@@ -20,7 +20,7 @@ SIMPLE_APP_SIGNATURE={{ secrets.server.config.simple_app_signature }}
 SIMPLE_SERVER_HOST={{ domain_name }}
 SIMPLE_SERVER_HOST_PROTOCOL=https
 SIMPLE_SERVER_DATABASE_HOST={{ groups.postgres_primary | first }}
-SIMPLE_SERVER_DATABASE_NAME={{ postgres.database_name }}
+SIMPLE_SERVER_DATABASE_NAME={{ database_name }}
 SIMPLE_SERVER_DATABASE_PASSWORD={{ secrets.postgres.password }}
 SIMPLE_SERVER_DATABASE_USERNAME={{ secrets.postgres.username }}
 

--- a/standalone/ansible/roles/load_balancing/templates/haproxy.cfg.j2
+++ b/standalone/ansible/roles/load_balancing/templates/haproxy.cfg.j2
@@ -55,7 +55,7 @@ backend {{ haproxy_backend_name }}
 {% endif %}
     cookie SERVERID insert indirect
 {% for server in groups.webservers %}
-    server simple-server{{ loop.index }} {{ server }}:80 cookie simple-server{{ loop.index }} check
+    server simple-server{{ loop.index }} {{ server }}:{{ nginx_port }} cookie simple-server{{ loop.index }} check
 {% endfor %}
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }

--- a/standalone/ansible/roles/monitoring/vars/main.yml
+++ b/standalone/ansible/roles/monitoring/vars/main.yml
@@ -4,6 +4,8 @@ node_exporter_port: 9100
 node_exporter_web_listen_address: "0.0.0.0:{{ node_exporter_port }}"
 prometheus_postgres_port: 9187
 redis_exporter_port: 9121
+redis_exporter_user: redis_exporter
+redis_exporter_group: redis_exporter
 
 alertmanager_web_port: 9093
 alertmanager_web_listen_address: '0.0.0.0:{{ alertmanager_web_port }}'

--- a/standalone/ansible/roles/passenger/templates/etc/nginx/sites-available/simple.org
+++ b/standalone/ansible/roles/passenger/templates/etc/nginx/sites-available/simple.org
@@ -2,7 +2,7 @@
 passenger_pre_start http://{{ domain_name }}/;
 
 server {
-  listen 80 default_server;
+  listen {{ nginx_port }} default_server;
   server_name {{ domain_name }};
 
   client_max_body_size 4G;


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172670823

## Because
The standalone ansible scripts have been tested so far on multiple services spread over multiple boxes. There are some quirks with running it on a single box that need to be addressed.

## This addresses

- Avoid nginx and haproxy port collision
- Avoid collision across group_vars