### PR TITLE
Update stale qa address

### DIFF
--- a/ansible/hosts.qa
+++ b/ansible/hosts.qa
@@ -1,5 +1,5 @@
 [simple]
-ec2-35-154-20-1.ap-south-1.compute.amazonaws.com
+ec2-52-66-174-119.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -1,5 +1,5 @@
 [simple]
-ec2-13-233-201-228.ap-south-1.compute.amazonaws.com
+ec2-13-127-111-26.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple


### PR DESCRIPTION
## Because

This repo has a stale address for the QA instance

[Simple-Server PR](https://github.com/simpledotorg/simple-server/pull/953)
## This addresses

Update the QA server address
