### PR TITLE
Configure things for diffable ansible vault secrets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.env* diff=ansible-vault merge=binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_STORE
 .terraform.tfvars
+.vault_password

--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ We use [terraform](https://www.terraform.io/) for provisioning servers and [ansi
 - [`standalone/`](/standalone) - Scripts for self-hosting simple-server (bare-metal servers/vanilla VMs). It sets up simple-server with the required peripherals (load balancing, monitoring etc.) and aims to be independent of third party applications as far as possible.
 - [`docs/`](/docs) - Miscellaneous docs.
 
+# Setting up Ansible Vault
+
+We use [ansible vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html) to manage encrypted secrets. The recommended way to set things up is below, which will allow you to use `ansible-vault` to view / edit encryptes files without having to
+contsantly type in the password. This setup will also allow you to use `git diff` locally on encrypted files and make sense of them. Otherwise you are just diff'ing binary blobs.
+
+1. Place the vault password in the repository root in a file named `.vault_password`. This file is gitignored and should never be checked in.
+2. Run the following to configure the diff driver
+```
+git config --global diff.ansible-vault.textconv "ansible-vault view"
+```
+3. Configure the vault password location in an env var - you'll probably want to add this to your shell profile:
+```
+export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
+```
+
+Now you can use git diff to view any changes locally on `.env` files.


### PR DESCRIPTION
To make this work:

* put the vault password in the repo root in a file named .vault_password
* Run the following to configure the diff driver

  git config --global diff.ansible-vault.textconv "ansible-vault view"

* Configure the vault password location in an env var - you'll probably want to add this to your shell profile:

  export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password 

Now git diff should just work for the encrypted files!

Source: https://stackoverflow.com/questions/29937195/how-to-diff-ansible-vault-changes
for the source for this.