### PR TITLE
Change node version to 10

### DIFF
--- a/ansible/roles/nodejs/vars/main.yml
+++ b/ansible/roles/nodejs/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # Set the version of Node.js to install ("6.x", "8.x", "9.x", "10.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "8.x"
+nodejs_version: "10.x"

--- a/standalone/ansible/roles/nodejs/vars/main.yml
+++ b/standalone/ansible/roles/nodejs/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # Set the version of Node.js to install ("6.x", "8.x", "9.x", "10.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "8.x"
+nodejs_version: "10.x"


### PR DESCRIPTION
We need node version 10 for for Tailwind / PostCSS. I hope all is in involved is changing this version number and running Ansible.

## Because

We want to use Tailwind

## This addresses

Upgrading Node to support newer node modules.
