### PR TITLE
Update sidekiq cpu threshold to 65%

### DIFF
--- a/terraform/modules/simple_server/cloudwatch.tf
+++ b/terraform/modules/simple_server/cloudwatch.tf
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_cpu" {
   namespace                 = "AWS/EC2"
   period                    = "60"
   statistic                 = "Average"
-  threshold                 = "22.5"
+  threshold                 = "65"
   alarm_actions             = [var.cloudwatch_alerts_sns_arn]
   ok_actions                = [var.cloudwatch_alerts_sns_arn]
   insufficient_data_actions = [var.cloudwatch_alerts_sns_arn]


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/173604616

Updates Sidekiq CPU threshold for cloudwatch alerts to 65%, consistent with our current IHCI production threshold.