### PR TITLE
Adjust alert thresholds

### DIFF
--- a/terraform/modules/simple_server/cloudwatch.tf
+++ b/terraform/modules/simple_server/cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "average_webserver_cpu" {
   namespace                 = "AWS/EC2"
   period                    = "60"
   statistic                 = "Average"
-  threshold                 = "22.5"
+  threshold                 = "65"
   alarm_actions             = [var.cloudwatch_alerts_sns_arn]
   ok_actions                = [var.cloudwatch_alerts_sns_arn]
   insufficient_data_actions = [var.cloudwatch_alerts_sns_arn]
@@ -42,10 +42,10 @@ resource "aws_cloudwatch_metric_alarm" "master_database_cpu" {
   count                     = var.enable_cloudwatch_alerts ? 1 : 0
   alarm_name                = "High CPU on master DB [${var.deployment_name}]"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
+  evaluation_periods        = "5"
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/RDS"
-  period                    = "60"
+  period                    = "300"
   statistic                 = "Average"
   threshold                 = "78"
   alarm_actions             = [var.cloudwatch_alerts_sns_arn]


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/778/adjust-cloudwatch-alert-thresholds

## Because

We are getting too many alerts, need to tune them.

## This addresses

Adjusts the thresholds.
