### PR TITLE
Remove unspecified SSH keys

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -71,12 +71,12 @@
   local_action: wait_for host={{ inventory_hostname }} port=22 delay=1 timeout=300
   when: restart_system.changed
 
-
 - name: add ssh keys for ubuntu
   become: true
-  authorized_key: key="{{ lookup('file', item) }}" user=ubuntu
-  with_fileglob:
-    - ssh_keys/{{ deploy_env }}/*
+  authorized_key:
+    key: "{% for key in query('fileglob', 'ssh_keys/{{ deploy_env }}/*') %}{{ lookup('file', key) ~ '\n'}}{% endfor %}"
+    user: ubuntu
+    exclusive: yes
 
 - name: ensure fail2ban is running
   become: true
@@ -118,9 +118,10 @@
 
 - name: add ssh keys for the deploy user
   become: true
-  authorized_key: key="{{ lookup('file', item) }}" user=deploy
-  with_fileglob:
-    - ssh_keys/{{ deploy_env }}/*
+  authorized_key:
+    key: "{% for key in query('fileglob', 'ssh_keys/{{ deploy_env }}/*') %}{{ lookup('file', key) ~ '\n'}}{% endfor %}"
+    user: deploy
+    exclusive: yes
 
 - name: enable systemctl services for deploy user
   become: true


### PR DESCRIPTION
**Story card:** -
## Because
We want to keep only the specified keys on our servers and remove old keys.

## This addresses
Keep only the keys present in `ssh_keys/<deploy_env>` exclusively.

Tested on `SBX` and `staging`.