### PR TITLE
Rename sidekiq elasticache

### DIFF
--- a/terraform/modules/simple_server/redis.tf
+++ b/terraform/modules/simple_server/redis.tf
@@ -11,7 +11,7 @@ resource "aws_elasticache_cluster" "simple_elasticache" {
   subnet_group_name    = var.redis_subnet_group_name
 
   tags = {
-    Name = "simple-elasticache-sandbox"
+    Name = "simple-elasticache"
   }
 }
 
@@ -28,7 +28,7 @@ resource "aws_elasticache_cluster" "simple_elasticache_2" {
   subnet_group_name    = var.redis_subnet_group_name
 
   tags = {
-    Name = "simple-elasticache-sandbox"
+    Name = "simple-elasticache"
   }
 }
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/363

## Because

We want to migrate our cache to a separate redis.

## This addresses

#228 added new redis boxes that were named `sidekiq-elasticache`. Since it's considerably more complicated to move sidekiq to the new redis than the cache, this renames the new elasticache to simply `elasticache-2` so we can use it for  whatever purpose.
