### PR TITLE
Update README w/ ansible-galaxy instructions for third party roles

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -12,7 +12,8 @@ You just need a few things installed locally.
 brew install ansible
 ```
 
-You then need to install any third party roles that we need - from this `ansible` directory:
+You then need to install any third party roles that we need via [ansible-galaxy](https://galaxy.ansible.com/docs/).
+Run the below from the `ansible` directory:
 
 ```
 ansible-galaxy install requirements.yml

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -12,6 +12,12 @@ You just need a few things installed locally.
 brew install ansible
 ```
 
+You then need to install any third party roles that we need - from this `ansible` directory:
+
+```
+ansible-galaxy install requirements.yml
+```
+
 ## Hosts
 
 These are the environments


### PR DESCRIPTION
I wish ansible had a standardized way for this, but I think this is the most common practice for this now.  