### PR TITLE
Update ET sempahore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,3 +44,5 @@ promotions:
     pipeline_file: update_india_production_config.yml
   - name: 9. Production Bangladesh - Update config
     pipeline_file: update_bangladesh_production_config.yml
+  - name: 9. Production Ethiopia - Update config
+    pipeline_file: update_ethiopia_production_config.yml

--- a/.semaphore/update_ethiopia_production_config.yml
+++ b/.semaphore/update_ethiopia_production_config.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Update Ethiopia Demo config
+name: Update Ethiopia Production config
 blocks:
   - name: Ansible update
     task:
@@ -9,7 +9,7 @@ blocks:
             - checkout
             - cd standalone
             - make init
-            - make update-app-config hosts=ethiopia/demo password_file=~/.ansible/vault_password_et
+            - make update-app-config hosts=ethiopia/production password_file=~/.ansible/vault_password_et
       secrets:
         - name: ansible ethiopia
         - name: semaphore-deploy-key


### PR DESCRIPTION
**Story card:**  [ch1604](https://app.clubhouse.io/simpledotorg/story/1604/create-subaccounts-for-the-it-team-for-various-third-party-services)

## Because

We wish to use a separate vault password for Ethiopia.

## This addresses

This updates the deploy pipeline to use the secret file added in https://github.com/simpledotorg/deployment/pull/274. The secret is already added to semaphore. This also adds ET production.
