### PR TITLE
Defend against Host-Header Injection

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-demo
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-demo
@@ -25,6 +25,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-bangladesh-production
@@ -25,6 +25,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-performance-feature
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-performance-feature
@@ -25,6 +25,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-performance-primary
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-performance-primary
@@ -25,6 +25,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
@@ -34,6 +34,7 @@ server {
   rails_env production;
   passenger_max_request_queue_size 200;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;
@@ -100,4 +101,3 @@ server {
     add_header Cache-Control public;
   }
 }
-

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
@@ -33,6 +33,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-sandbox
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-sandbox
@@ -34,6 +34,7 @@ server {
     passenger_enabled on;
     rails_env production;
     passenger_start_timeout 300;
+    passenger_set_header X-Forwarded-Host $http_host;
 
     gzip on;
     gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-security
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-security
@@ -34,6 +34,7 @@ server {
     passenger_enabled on;
     rails_env production;
     passenger_start_timeout 300;
+    passenger_set_header X-Forwarded-Host $http_host;
 
     gzip on;
     gzip_types text/html text/plain application/json;

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-staging
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-staging
@@ -33,6 +33,7 @@ server {
   passenger_enabled on;
   rails_env production;
   passenger_start_timeout 300;
+  passenger_set_header X-Forwarded-Host $http_host;
 
   gzip on;
   gzip_types text/html text/plain application/json;


### PR DESCRIPTION
**Story card:** [ch1730](https://app.clubhouse.io/simpledotorg/story/1730/host-header-injection-vulnerability)

## Because

For context, refer to https://github.com/simpledotorg/simple-server/pull/1467.

## This addresses

This is a better solution than https://github.com/simpledotorg/simple-server/pull/1467, since it force sets the `X-Forwarded-Host` to default to `HTTP_HOST` header in the nginx/passenger layer. This ensures that any poisoning of the header will not be honored.

**Note**: `HTTP_HOST` header should and must always be set, so we should never run into any issues when it's not set and hence `X-Forwarded-Host` is not set.

**Note**: We have intentionally skipped doing this for Ethiopia, since the setup there is a little different and required more testing across HAProxy and such.

