### PR TITLE
Standalone: Adjust redis alert threshold

### DIFF
--- a/standalone/ansible/roles/monitoring/files/prometheus/rules/redis.rules
+++ b/standalone/ansible/roles/monitoring/files/prometheus/rules/redis.rules
@@ -20,7 +20,7 @@ groups:
         description: "Redis is running out of memory (> 90%)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
 
     - alert: RedisTooManyConnections
-      expr: redis_connected_clients > 100
+      expr: redis_connected_clients > 170
       for: 2m
       labels:
         severity: warning


### PR DESCRIPTION
**Story card:** NA

## Because

The number of redis connections on ET is too high and we are getting alerts about it. We have taken note of this and will fix it soon. Increasing the alert threshold to reduce noise meanwhile.