### PR TITLE
add ethiopia telegram info for help screen

### DIFF
--- a/standalone/ansible/roles/simple-server/templates/.env.j2
+++ b/standalone/ansible/roles/simple-server/templates/.env.j2
@@ -37,6 +37,8 @@ HELP_SCREEN_YOUTUBE_PASSPORT_URL="https://youtu.be/aktZ1yTdDOA"
 HELP_SCREEN_YOUTUBE_TRAINING_URL="https://youtu.be/MC_45DoRw2g"
 HELP_SCREEN_WHATSAPP_SUPPORT_GROUP_URL="https://wa.me/916280258024/?text=I%20would%20like%20to%20ask%20a%20question%20about%20Simple.%20"
 HELP_SCREEN_WHATSAPP_SUPPORT_NUMBER="+91 6280258024"
+HELP_SCREEN_ETHIOPIA_SUPPORT_GROUP_URL="https://t.me/ment_GG"
+HELP_SCREEN_ETHIOPIA_SUPPORT_NUMBER="+25 1967281756"
 
 EXOTEL_SID={{ secrets.server.config.exotel_sid }}
 EXOTEL_TOKEN={{ secrets.server.config.exotel_token }}


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1938/update-help-contact-info
**Simple Server PR** https://github.com/simpledotorg/simple-server/pull/1546
## Because

The Ethiopia Help screen needs to show a telegram link and phone number

## This addresses

Adds the Ethiopia specific help info to the template
