### PR TITLE
Resize performance boxes 

### DIFF
--- a/ansible/hosts.performance-feature
+++ b/ansible/hosts.performance-feature
@@ -1,5 +1,5 @@
 [simple]
-65.0.55.38
+13.232.178.205
 
 [rails:children]
 simple

--- a/ansible/hosts.performance-primary
+++ b/ansible/hosts.performance-primary
@@ -1,5 +1,5 @@
 [simple]
-13.233.31.62
+13.233.237.184
 
 [rails:children]
 simple


### PR DESCRIPTION
**Story card:** -

## Because

The performance boxes are a t2.large. Bump them up to test how block level sync would work on prod boxes (which we will bump to t2.xlarge soon as well).

Server PR: https://github.com/simpledotorg/simple-server/pull/1890