### PR TITLE
Ethiopia SSL certificate docs

### DIFF
--- a/docs/ethiopia/ethiopia-infrastructure.md
+++ b/docs/ethiopia/ethiopia-infrastructure.md
@@ -1,0 +1,52 @@
+# Infrastructure
+
+##### IP Addresses
+
+The two Ethiopia production servers are accessible through public IP addresses as well as internal IP addresses if you
+are in the network.
+
+```
+Box 1:
+  Public IP:   197.156.66.181
+  Internal IP: 172.19.0.241
+Box 2:
+  Public IP:   197.156.66.178
+  Internal IP: 172.19.0.240
+```
+
+When managing the production servers from outside the internal network, the [`production`](../standalone/hosts/ethiopia/production)
+hosts file should be used with `make`/`ansible` commands.
+
+When managing the production servers from inside the internal network, the [`production-internal`](../standalone/hosts/ethiopia/production-internal)
+hosts file can be used with `make`/`ansible` commands.
+
+![Ethiopia Server Topography](ethiopia-server-topography.png)
+This diagram can be edited [here](https://docs.google.com/drawings/d/1iEGHXp1xEOsAVg8zKHnIB17sQHRZdeES9XDjacTSTFA/edit).
+
+##### Load balancing:
+- Both instances run an instance of HAProxy. `api.et.simple.org` currently points to `Box 1`. The second box's load balancer
+is for redundancy and is not pointed to by a DNS. It is however configured to talk to the webservers already.
+
+##### Web server and sidekiq:
+- Both boxes run an instance of the Rails webserver and sidekiq (for background job processing). At all times, these services need to talk to:
+    - Primary Postgres DB
+    - Redis
+
+##### Postgres:
+- Both boxes run an instance of postgres. Postgres on `Box 1` is the primary database. `Box 2` is a hot standby, which can be
+  quickly promoted to primary in a contingency.
+
+##### Logs:
+
+All logs are shipped to `Box 2`. DB backups are periodically shipped to Box 2 as well.
+
+#### If `Box 1` dies
+
+- Promote postgres replica on `Box 2` to become master; Change rails config to talk to postgres on `Box 2`.
+    - (TODO: Add steps/commands here)
+- Update Rails and Sidekiq config to talk to redis on `Box 2`.
+- Setup monitoring daemons (grafana, prometheus) to run on `Box 2`.
+- Point `api.et.simple.org` DNS in cloudflare to `Box 2`.
+
+#### If `Box 2` dies
+- Nothing critical is affected, `simple-server` will continue to run smoothly. Postgres replication, logshipping will stop.

--- a/docs/ethiopia/ethiopia-playbook.md
+++ b/docs/ethiopia/ethiopia-playbook.md
@@ -1,6 +1,6 @@
-## Ethiopia Playbook
+# Ethiopia Playbook
 
-### Deployment
+## Deployment
 
 First up, make sure you have the specific Ethiopia private vault key to decrypt the secret configuration and credentials. Ask someone on the Simple team, if you're unsure.
 
@@ -10,66 +10,14 @@ Currently, the ET releases are made through [Semaphore](https://resolvetosaveliv
 
 There are 2 active environments on Ethiopia.
 
-##### Demo ([Pipeline](https://github.com/simpledotorg/simple-server/blob/master/.semaphore/ethiopia_demo_deployment.yml))
+### Demo ([Pipeline](https://github.com/simpledotorg/simple-server/blob/master/.semaphore/ethiopia_demo_deployment.yml))
 
 This is deployed on the RTSL Digital Ocean account.
 
-##### Production ([Pipeline](https://github.com/simpledotorg/simple-server/blob/master/.semaphore/ethiopia_production_deployment.yml))
+### Production ([Pipeline](https://github.com/simpledotorg/simple-server/blob/master/.semaphore/ethiopia_production_deployment.yml))
 This is deployed on the bare-metal Dell servers in Ethiopia datacenters.
 
-### Contigency Plan
+## Guides and Documentation
 
-When something goes wrong on the self-managed standalone Ethiopia production servers.
-
-#### Notes on configuration:
-
-##### IP Addresses
-
-The two Ethiopia production servers are accessible through public IP addresses as well as internal IP addresses if you
-are in the network.
-
-```
-Box 1:
-  Public IP:   197.156.66.181
-  Internal IP: 172.19.0.241
-Box 2:
-  Public IP:   197.156.66.178
-  Internal IP: 172.19.0.240
-```
-
-When managing the production servers from outside the internal network, the [`production`](../standalone/hosts/ethiopia/production)
-hosts file should be used with `make`/`ansible` commands.
-
-When managing the production servers from inside the internal network, the [`production-internal`](../standalone/hosts/ethiopia/production-internal)
-hosts file can be used with `make`/`ansible` commands.
-
-![Ethiopia Server Topography](ethiopia-server-topography.png)
-This diagram can be edited [here](https://docs.google.com/drawings/d/1iEGHXp1xEOsAVg8zKHnIB17sQHRZdeES9XDjacTSTFA/edit).
-
-##### Load balancing:
-- Both instances run an instance of HAProxy. `api.et.simple.org` currently points to `Box 1`. The second box's load balancer
-is for redundancy and is not pointed to by a DNS. It is however configured to talk to the webservers already.
-
-##### Web server and sidekiq:
-- Both boxes run an instance of the Rails webserver and sidekiq (for background job processing). At all times, these services need to talk to:
-    - Primary Postgres DB
-    - Redis
-
-##### Postgres:
-- Both boxes run an instance of postgres. Postgres on `Box 1` is the primary database. `Box 2` is a hot standby, which can be
-  quickly promoted to primary in a contingency.
-
-##### Logs:
-
-All logs are shipped to `Box 2`. DB backups are periodically shipped to Box 2 as well.
-
-#### If `Box 1` dies
-
-- Promote postgres replica on `Box 2` to become master; Change rails config to talk to postgres on `Box 2`.
-    - (TODO: Add steps/commands here)
-- Update Rails and Sidekiq config to talk to redis on `Box 2`.
-- Setup monitoring daemons (grafana, prometheus) to run on `Box 2`.
-- Point `api.et.simple.org` DNS in cloudflare to `Box 2`.
-
-#### If `Box 2` dies
-- Nothing critical is affected, `simple-server` will continue to run smoothly. Postgres replication, logshipping will stop.
+* [Infrastructure](ethiopia-infrastructure.md)
+* [Install/Update SSL Certificates](ethiopia-ssl-certificates.md)

--- a/docs/ethiopia/ethiopia-ssl-certificates.md
+++ b/docs/ethiopia/ethiopia-ssl-certificates.md
@@ -92,5 +92,5 @@ Open a pull request in Github with your changes. The Simple team will accept you
 In the meantime, you don't have to wait. You can immediately install the new certificate on Simple Server from the deployment repository.
 
 ```bash
-make all hosts=ethiopia/demo
+make update-ssl-certs hosts=ethiopia/demo
 ```

--- a/docs/ethiopia/ethiopia-ssl-certificates.md
+++ b/docs/ethiopia/ethiopia-ssl-certificates.md
@@ -1,0 +1,96 @@
+# Installing a new SSL certificate in Simple Server
+
+## Generate the certificate
+
+Install certbot if necessary
+
+```bash
+sudo apt-get install certbot
+```
+
+Stop haproxy and nginx
+
+```bash
+sudo service nginx stop
+sudo service haproxy stop
+```
+
+Generate a standalone certificate on the server
+
+```bash
+sudo certbot certonly --standalone -d simple.moh.gov.et
+```
+
+Restart haproxy and nginx
+
+```bash
+sudo service nginx start
+sudo service haproxy start
+```
+
+Grab the contents of the generated certificate
+
+```bash
+cat /etc/letsencrypt/live/simple.moh.gov.et/privkey.pem
+cat /etc/letsencrypt/live/simple.moh.gov.et/fullchain.pem
+```
+
+## Check in the new certificate
+
+Fetch the latest updates to the deployment repository.
+
+```bash
+cd ~/deployment
+git checkout master
+git pull --rebase origin master
+```
+
+Decrypt the `ssl-vault.yml`
+
+```bash
+cd standalone/ansible/roles/load_balancing/vars
+ansible-vault decrypt --vault-id ~/.vault_password_et ssl-vault.yml
+```
+
+Add the new fullchain and private key files to the decrypted ssl-vault.yml
+
+```yml
+ssl_cert_files:
+  /etc/ssl/simple.moh.gov.et.crt:
+    owner: root
+    group: root
+    mode: "u=r,go="
+    content: |
+    <Contents of the new fullchain.pem>
+  /etc/ssl/simple.moh.gov.et.key:
+    owner: root
+    group: root
+    mode: "u=r,go="
+    content: |
+    <Contents of the new privkey.pem>
+```
+
+Re-encrypt the `ssl-vault.yml`
+
+```bash
+ansible-vault encrypt --vault-id ~/.vault_password_et ssl-vault.yml
+```
+
+Commit and push your updates. **Caution: Be sure to re-encrypt the `ssl-vault.yml` before commiting your changes!**
+
+```bash
+cd ~/deployment
+git add standalone/ansible/roles/load_balancing/vars/ssl-vault.yml
+git commit -m 'Update SSL certificate'
+git push siraj master
+```
+
+Open a pull request in Github with your changes. The Simple team will accept your changes in a few days.
+
+## Install/Update the SSL Certificates
+
+In the meantime, you don't have to wait. You can immediately install the new certificate on Simple Server from the deployment repository.
+
+```bash
+make all hosts=ethiopia/demo
+```

--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -44,6 +44,9 @@ update-ssh-keys: ##@Utilities Update ssh keys on boxes. Add keys to `ansible/rol
 update-app-config: ##@Utilities Update app config .env file
 	ansible-playbook --vault-id $(password_file) ansible/deploy.yml -i hosts/$(hosts) --tags update-app-config
 
+update-ssl-certs: ##@Utilities Update the SSL certs. Add the appropriate certs under the encrypted ssl-vault.yml
+	ansible-playbook --vault-id $(password_file) ansible/load_balancing.yml -i hosts/$(hosts) --tags load_balancing
+
 restart-passenger: ##@Utilities Restart passenger
 	ansible-playbook --vault-id $(password_file) ansible/setup.yml -i hosts/$(hosts) -l webservers --tags restart-passenger
 


### PR DESCRIPTION
**Story card:** [ch2122](https://app.clubhouse.io/simpledotorg/story/2122/update-ethiopia-production-domain)

Add documentation to Ethiopia playbook on how to install/update SSL certificates.

This documentation is based on how we installed certificates with Siraj yesterday. It also includes a convenience make task `update-ssl-certs` that will only update SSL certs - a quicker alternative to `make all`.