### PR TITLE
Configure simple.moh.gov.et from addresses for mailers

### DIFF
--- a/standalone/ansible/roles/simple-server/templates/.env.j2
+++ b/standalone/ansible/roles/simple-server/templates/.env.j2
@@ -1,6 +1,6 @@
 DEFAULT_NUMBER_OF_RECORDS=100
 DEFAULT_COUNTRY={{ default_country }}
-MAILERS_FROM={{ mailers_from }}
+MAILERS_FROM=help@{{ domain_name }}
 
 SECRET_KEY_BASE={{ secrets.server.config.secret_key_base }}
 

--- a/standalone/ansible/roles/simple-server/templates/.env.j2
+++ b/standalone/ansible/roles/simple-server/templates/.env.j2
@@ -1,5 +1,6 @@
 DEFAULT_NUMBER_OF_RECORDS=100
 DEFAULT_COUNTRY={{ default_country }}
+MAILERS_FROM={{ mailers_from }}
 
 SECRET_KEY_BASE={{ secrets.server.config.secret_key_base }}
 

--- a/standalone/hosts/ethiopia/demo
+++ b/standalone/hosts/ethiopia/demo
@@ -1,9 +1,10 @@
 [all:vars]
-deploy_env=ethiopia-demo
-app_env=demo
-domain_name=simple-demo.moh.gov.et
-default_country=ET
 analytics_dashboard_cache_ttl=60
+app_env=demo
+default_country=ET
+deploy_env=ethiopia-demo
+domain_name=simple-demo.moh.gov.et
+mailers_from=help@simple-demo.moh.gov.et
 
 [postgres:children]
 postgres_primary

--- a/standalone/hosts/ethiopia/demo
+++ b/standalone/hosts/ethiopia/demo
@@ -4,7 +4,6 @@ app_env=demo
 default_country=ET
 deploy_env=ethiopia-demo
 domain_name=simple-demo.moh.gov.et
-mailers_from=help@simple-demo.moh.gov.et
 
 [postgres:children]
 postgres_primary

--- a/standalone/hosts/ethiopia/production
+++ b/standalone/hosts/ethiopia/production
@@ -1,9 +1,10 @@
 [all:vars]
-deploy_env=ethiopia-production
-app_env=production
-domain_name=simple.moh.gov.et
-default_country=ET
 analytics_dashboard_cache_ttl=86400
+app_env=production
+default_country=ET
+deploy_env=ethiopia-production
+domain_name=simple.moh.gov.et
+mailers_from=help@simple.moh.gov.et
 
 [postgres:children]
 postgres_primary

--- a/standalone/hosts/ethiopia/production
+++ b/standalone/hosts/ethiopia/production
@@ -4,7 +4,6 @@ app_env=production
 default_country=ET
 deploy_env=ethiopia-production
 domain_name=simple.moh.gov.et
-mailers_from=help@simple.moh.gov.et
 
 [postgres:children]
 postgres_primary


### PR DESCRIPTION
**Story card:** [ch2497](https://app.clubhouse.io/simpledotorg/story/2497/send-emails-from-moh-gov-et)

We should configure our mailers in Ethiopia to be "from" the moh.gov.et subdomain, to match the deployment of Simple server.

Related server PR: https://github.com/simpledotorg/simple-server/pull/2032