### PR TITLE
Keep lesser logs on servers

### DIFF
--- a/ansible/roles/common/files/etc/logrotate.d/rails
+++ b/ansible/roles/common/files/etc/logrotate.d/rails
@@ -1,7 +1,7 @@
 /home/deploy/apps/*/current/log/*.log {
   su deploy deploy
   daily
-  rotate 14
+  rotate 2
   missingok
   notifempty
   compress

--- a/ansible/roles/common/files/etc/logrotate.d/rails
+++ b/ansible/roles/common/files/etc/logrotate.d/rails
@@ -1,7 +1,7 @@
 /home/deploy/apps/*/current/log/*.log {
   su deploy deploy
   daily
-  rotate 2
+  rotate 3
   missingok
   notifempty
   compress


### PR DESCRIPTION
**Story card:** - 

## Because

Our daily audit logs are growing in size. We currently keep the last 14 days of logs on each box, which is unnecessary since we ship logs to s3 daily. Some of our boxes have been running out of disk space sporadically because of this.

## This addresses

This keeps only 2 days of logs on the box itself instead of 14 days.
