### PR TITLE
Update node_exporter package name

### DIFF
--- a/standalone/README.md
+++ b/standalone/README.md
@@ -210,12 +210,12 @@ This will provision the necessary servers for an instance of simple-server on di
 
 Depending on your system, you may run into the following known issues:
 
-### Errors with cloudalchemy.node-exporter
+### Errors with cloudalchemy.node_exporter
 
 If you see output like this, it's likely due to [this issue](https://github.com/cloudalchemy/ansible-node-exporter/issues/54).
 
 ```
-TASK [cloudalchemy.node-exporter : Get checksum list from github] *******************************************************************************************************************************************************
+TASK [cloudalchemy.node_exporter : Get checksum list from github] *******************************************************************************************************************************************************
 objc[5848]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
 objc[5848]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
 ERROR! A worker was found in a dead state

--- a/standalone/ansible/monitoring.yml
+++ b/standalone/ansible/monitoring.yml
@@ -3,7 +3,7 @@
   hosts: all
   roles:
     - monitoring
-    - cloudalchemy.node-exporter
+    - cloudalchemy.node_exporter
 
 - name: setup postgres exporter
   hosts: postgres

--- a/standalone/ansible/requirements.yml
+++ b/standalone/ansible/requirements.yml
@@ -4,7 +4,7 @@
 - src: cloudalchemy.prometheus
 - src: cloudalchemy.alertmanager
 - src: cloudalchemy.grafana
-- src: cloudalchemy.node-exporter
+- src: cloudalchemy.node_exporter
 - src: davidwittman.redis
 - src: ome.prometheus_postgres
 - src: http://github.com/idealista/prometheus_redis_exporter_role.git


### PR DESCRIPTION
**Story card:** <pivotal story link>

## Because

The `node-exporter` package's name changed upstream. Ref: https://github.com/cloudalchemy/ansible-node-exporter/pull/206

## This addresses

Updates the packages name.
