### PR TITLE
Standalone: Fix rsync of postgres backups

### DIFF
--- a/standalone/ansible/roles/postgres/templates/pg_backup.sh
+++ b/standalone/ansible/roles/postgres/templates/pg_backup.sh
@@ -15,7 +15,7 @@ if ! pg_dump -U {{ secrets.postgres.username }} {{ postgres.database_name }} | g
 else
     mv "$FILENAME".sql.gz.in_progress "$FILENAME".sql.gz
   {% for server in groups.storage %}
-    rsync -a "$BACKUP_DIR"* {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/ --log-file=rsync.log
+    rsync -a "$BACKUP_DIR"* {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/ --log-file="$FILENAME"-rsync.log
   {% endfor %}
 fi
 

--- a/standalone/ansible/roles/postgres/templates/pg_backup.sh
+++ b/standalone/ansible/roles/postgres/templates/pg_backup.sh
@@ -15,7 +15,7 @@ if ! pg_dump -U {{ secrets.postgres.username }} {{ postgres.database_name }} | g
 else
     mv "$FILENAME".sql.gz.in_progress "$FILENAME".sql.gz
   {% for server in groups.storage %}
-    rsync -a "$BACKUP_DIR"*.gz {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/
+    rsync -a "$BACKUP_DIR"* {{ deploy_user }}@{{ server }}:{{ backups_destination_dir }}/$HOSTNAME/ --log-file=rsync.log
   {% endfor %}
 fi
 

--- a/standalone/ansible/roles/storage/tasks/main.yml
+++ b/standalone/ansible/roles/storage/tasks/main.yml
@@ -11,13 +11,13 @@
 - name: fetch remote user ssh keys to be added to storage server
   fetch:
     src: "~/.ssh/id_rsa.pub"
-    dest: "/tmp/keys/{{ inventory_hostname }}-id_rsa.pub"
+    dest: "/tmp/keys/{{ inventory_hostname }}-remote-user-id_rsa.pub"
     flat: yes
 
 - name: fetch root user ssh keys to be added to storage server
   fetch:
     src: "~/.ssh/id_rsa.pub"
-    dest: "/tmp/keys/{{ inventory_hostname }}-id_rsa.pub"
+    dest: "/tmp/keys/{{ inventory_hostname }}-root-user-id_rsa.pub"
     flat: yes
   become: true
 


### PR DESCRIPTION
**Story card:** -

## Because

We noticed that postgres backups aren't being shipped to the storage box on ET. [Slack ref](https://simpledotorg.slack.com/archives/C01CK7DETLM/p1614947755002100)

## This addresses

Ensure that both `ubuntu` and `root` keys are both available and authorized on the storage box.

It appears we were accidentally clobbering the `ubuntu` keys when we write the `root` keys to the storage box. Because of this, rsync tasks that are executed as `root` (postgres logs, redis logs) succeed, but those executed as `ubuntu` (postgres backups) have been failing.