### PR TITLE
Clear postgres backups from postgres server after 14 days

### DIFF
--- a/standalone/ansible/group_vars/postgres.yml
+++ b/standalone/ansible/group_vars/postgres.yml
@@ -23,5 +23,5 @@ rsync_destination_dir: "/home/{{ deploy_user }}/logs/postgres"
 prometheus_postgres_dbname: "{{ postgres.database_name }}"
 backups_dir: "backups/"
 backups_destination_dir: "/home/{{ deploy_user }}/backups/postgres"
-backups_days_to_keep: 30
+backups_days_to_keep: 14
 

--- a/standalone/ansible/roles/postgres/templates/pg_backup.sh
+++ b/standalone/ansible/roles/postgres/templates/pg_backup.sh
@@ -19,4 +19,4 @@ else
   {% endfor %}
 fi
 
-find $BACKUP_DIR -maxdepth 0 -mtime +$DAYS_TO_KEEP -exec rm -rf '{}' ';'
+find $BACKUP_DIR -maxdepth 1 -mtime +$DAYS_TO_KEEP -exec rm -rf '{}' ';'


### PR DESCRIPTION
**Story card:** [ch2854](https://app.clubhouse.io/simpledotorg/story/2854/ethiopia-clear-local-postgres-backups-after-they-ve-been-rsynced-to-the-storage-box)

## Because

Postgres backups don't get cleared from the postgres instance after being shipped to the storage instance.
![image](https://user-images.githubusercontent.com/16774200/117624717-d7df2880-b192-11eb-81f3-fd6c66accd54.png)

## This addresses

Fixes the backup script.
