### PR TITLE
Fix grafana config

### DIFF
--- a/standalone/ansible/roles/monitoring/vars/grafana.yml
+++ b/standalone/ansible/roles/monitoring/vars/grafana.yml
@@ -6,7 +6,10 @@ grafana_datasources:
   - name: prometheus
     type: prometheus
     access: proxy
-    url: "http://{{ groups.prometheus.0 }}:{{ prometheus_port }}"
+    url: "http://{{ domain_name}}/prometheus"
+    basicAuth: true
+    basicAuthUser: admin
+    basicAuthPassword: "{{ monitoring_dashboard_password }}"
 grafana_dashboards:
   - dashboard_id: 11074 # Node exporter
     revision_id: 2


### PR DESCRIPTION
**Story card:** -

## Because

While digging into grafana on ET, discovered that the dashboards aren't being populated. We added basic auth to the prometheus exporter in #271 but didn't add the creds to grafana's config. 

## This addresses

This adds basic auth creds to grafana config.
