### PR TITLE
Ensure DHIS2 credentials are added to .env template

### DIFF
--- a/standalone/ansible/roles/simple-server/templates/.env.j2
+++ b/standalone/ansible/roles/simple-server/templates/.env.j2
@@ -79,6 +79,11 @@ BACKFILL_ENCOUNTERS_FOR_BPS_TIMEZONE_OFFSET=19800
 SUPERVISOR_EMAILS=
 OWNER_EMAILS=
 
+DHIS2_URL={{ secrets.server.config.dhis2_url }}
+DHIS2_USERNAME={{ secrets.server.config.dhis2_username }}
+DHIS2_PASSWORD={{ secrets.server.config.dhis2_password }}
+DHIS2_VERSION={{ secrets.server.config.dhis2_version }}
+
 {% for feature, value in feature_flags.server.config.items() %}
 {{ feature | upper }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Follow-up for #341 

In #341, we added empty DHIS2 creds to our `secrets.yml` files for Ethiopia deployments. However, we didn't insert those new creds into the `.env.j2` template. This PR makes sure that the empty creds are _used_, and added to the `.env.production` file that finally lands on the servers.