### PR TITLE
Set a content length limit on api requests

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-production
@@ -58,6 +58,10 @@ server {
     expires    max;
     add_header Cache-Control public;
   }
+
+  location /api/ {
+    client_max_body_size 5M;
+  }
 }
 
 server {
@@ -99,5 +103,9 @@ server {
   location = /favicon.ico {
     expires    max;
     add_header Cache-Control public;
+  }
+
+  location /api/ {
+    client_max_body_size 5M;
   }
 }

--- a/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
+++ b/ansible/roles/passenger/files/etc/nginx/sites-available/simple.org-qa
@@ -57,6 +57,10 @@ server {
     expires    max;
     add_header Cache-Control public;
   }
+
+  location /api/ {
+    client_max_body_size 5M;
+  }
 }
 
 server {
@@ -98,5 +102,9 @@ server {
   location = /favicon.ico {
     expires    max;
     add_header Cache-Control public;
+  }
+
+  location /api/ {
+    client_max_body_size 5M;
   }
 }


### PR DESCRIPTION
**Story card:** [ch4055](https://app.clubhouse.io/simpledotorg/story/4055/investigate-ec2-cpu-spikes)

## Because

We have been receiving CPU spikes on EC2. Some users are syncing gigantic payloads to the server (POST). These patients are `identical` and are being synced over and over. The app times out while syncing them and considers them `unsynced` perpetually. 

The problematic patient payloads sizes range from 10Mb to 14Mb. This is roughly ~8-10k patients. These are the requests that caused the CPU spikes. There are potentially smaller requests that don't cause a CPU spike but also timeout on the client and resync.

## This addresses

This is a stopgap to prevent the large payloads from hitting rails. We will drop API requests > 5Mb on nginx. This will allow us to:
- Confirm why these requests are being sent to us in the first place. Possible lead: A Jan 2020 data migration on the app that marked all patients unsynced.
- Work on batching sync pushes from the app
- What takes up CPU when a large payload comes in. Validations?

Tested on QA