### PR TITLE
Update node to version 12

### DIFF
--- a/ansible/roles/nodejs/vars/main.yml
+++ b/ansible/roles/nodejs/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # Set the version of Node.js to install ("6.x", "8.x", "9.x", "10.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "10.x"
+nodejs_version: "12.x"

--- a/standalone/ansible/roles/nodejs/vars/main.yml
+++ b/standalone/ansible/roles/nodejs/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # Set the version of Node.js to install ("6.x", "8.x", "9.x", "10.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "10.x"
+nodejs_version: "12.x"


### PR DESCRIPTION
**Story card:** [ch4424](https://app.clubhouse.io/simpledotorg/story/4424/update-node-to-a-version-compatible-with-webpack)

## Because

We need a more recent version of node for webpack.

Ran on sandbox and qa successfully:

```
ansible-playbook -v --vault-id ../.vault_password deploy.yml -i hosts.sandbox --tags nodejs
```

Failed on bangladesh-demo:

```
[~/src/simpledotorg/deployment/ansible (node-update)]> ansible-playbook -v --vault-id ../.vault_password deploy.yml -i hosts.bangladesh-demo --tags nodejs
Using /Users/rsanheim/src/simpledotorg/deployment/ansible/ansible.cfg as config file
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
[DEPRECATION WARNING]: 'include' for playbook includes. You should use 'import_playbook' instead. This feature will be
removed from ansible-base in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.

PLAY [rails] ****************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************
[DEPRECATION WARNING]: Distribution Ubuntu 16.04 on host ec2-15-207-249-148.ap-south-1.compute.amazonaws.com should use
/usr/bin/python3, but is using /usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible
release will default to using the discovered platform python for this host. See
https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information. This feature
will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [ec2-15-207-249-148.ap-south-1.compute.amazonaws.com]
[DEPRECATION WARNING]: Distribution Ubuntu 16.04 on host ec2-13-233-8-130.ap-south-1.compute.amazonaws.com should use
/usr/bin/python3, but is using /usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible
release will default to using the discovered platform python for this host. See
https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information. This feature
will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [ec2-13-233-8-130.ap-south-1.compute.amazonaws.com]

TASK [nodejs : ensure apt-transport-https is installed] *********************************************************************
ok: [ec2-15-207-249-148.ap-south-1.compute.amazonaws.com] => {"cache_update_time": 1628137241, "cache_updated": false, "changed": false}
ok: [ec2-13-233-8-130.ap-south-1.compute.amazonaws.com] => {"cache_update_time": 1628157930, "cache_updated": false, "changed": false}

TASK [nodejs : add NodeSource apt key] **************************************************************************************
ok: [ec2-15-207-249-148.ap-south-1.compute.amazonaws.com] => {"changed": false}
ok: [ec2-13-233-8-130.ap-south-1.compute.amazonaws.com] => {"changed": false}

TASK [nodejs : add NodeSource repositories for node.js] *********************************************************************
failed: [ec2-15-207-249-148.ap-south-1.compute.amazonaws.com] (item=deb https://deb.nodesource.com/node_12.x xenial main) => {"ansible_loop_var": "item", "changed": false, "item": "deb https://deb.nodesource.com/node_12.x xenial main", "msg": "Failed to update apt cache: unknown reason"}
failed: [ec2-13-233-8-130.ap-south-1.compute.amazonaws.com] (item=deb https://deb.nodesource.com/node_12.x xenial main) => {"ansible_loop_var": "item", "changed": false, "item": "deb https://deb.nodesource.com/node_12.x xenial main", "msg": "Failed to update apt cache: unknown reason"}
```