### PR TITLE
standalone: Fix haproxy restart after updating certs

### DIFF
--- a/standalone/ansible/roles/load_balancing/handlers/main.yml
+++ b/standalone/ansible/roles/load_balancing/handlers/main.yml
@@ -1,2 +1,0 @@
-- name: restart haproxy
-  service: name=haproxy state=restarted

--- a/standalone/ansible/roles/load_balancing/tasks/main.yml
+++ b/standalone/ansible/roles/load_balancing/tasks/main.yml
@@ -40,7 +40,6 @@
   copy:
     content: "{{ haproxy_cert_names | map('regex_replace', '^(.*)$', '\\1.pem') | join('\n') }}"
     dest: "{{ haproxy_crt_list }}"
-  notify: restart haproxy
   become: true
 
 - name: update HAProxy config
@@ -48,7 +47,6 @@
     src: haproxy.cfg.j2
     dest: /etc/haproxy/haproxy.cfg
     backup: yes
-  notify: restart haproxy
   become: true
 
 - name: allow all tcp access to port 80
@@ -71,6 +69,11 @@
     port: "{{ haproxy_stats_port }}"
     proto: tcp
   become: true
+
+- name: restart haproxy
+  service:
+    name: haproxy
+    state: restarted
 
 - name: restart rsyslog to begin logging
   service:


### PR DESCRIPTION
**Story card:** [ch5340](https://app.shortcut.com/simpledotorg/story/5340/standalone-restart-haproxy-after-ssl-certificate-update)

## Because

We found that the `notify: restart haproxy` handler didn't run when a cert was updated. This causes a newly deployed cert to not be in effect until the next haproxy restart.

## This addresses

Restarts haproxy mandatorily at the end of the playbook.
