### PR TITLE
Fix standalone rails logshipping

### DIFF
--- a/standalone/ansible/logshipping.yml
+++ b/standalone/ansible/logshipping.yml
@@ -6,7 +6,7 @@
     - { role: logshipping, tags: ['logshipping'] }
 - hosts: servers
   vars_files:
-    - group_vars/postgres.yml
+    - group_vars/servers.yml
   roles:
     - { role: logshipping, tags: ['logshipping'] }
 - hosts: redis


### PR DESCRIPTION
**Story card:** [ch5612](https://app.shortcut.com/simpledotorg/story/5612/fix-rails-logshipping-in-standalone-scripts?ct_workflow=all)

## Because

Rails logs aren't being shipped to the storage box because the right vars weren't being loaded in the logshipping role.

## This addresses

Fixes the logshipping role.
