### PR TITLE
Upgraded Bangladesh instances to t3.xlarge on AWS

### DIFF
--- a/ansible/hosts.bangladesh-production
+++ b/ansible/hosts.bangladesh-production
@@ -1,7 +1,7 @@
 [simple]
-ec2-13-234-38-169.ap-south-1.compute.amazonaws.com
-ec2-13-233-73-120.ap-south-1.compute.amazonaws.com
-ec2-13-235-248-148.ap-south-1.compute.amazonaws.com
+ec2-13-232-216-97.ap-south-1.compute.amazonaws.com
+ec2-13-234-48-121.ap-south-1.compute.amazonaws.com
+ec2-13-232-171-227.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple


### PR DESCRIPTION
**Story card:** [ch5742](https://app.shortcut.com/simpledotorg/story/5742/upgrade-the-bangladesh-production-machines-to-larger-sizes)

## Because

Bangladesh machines were only 4gb of RAM; this upgrades to 16gb