### PR TITLE
Standalone: increase haproxy health check interval

### DIFF
--- a/standalone/ansible/roles/load_balancing/templates/haproxy.cfg.j2
+++ b/standalone/ansible/roles/load_balancing/templates/haproxy.cfg.j2
@@ -80,7 +80,7 @@ backend webservers
 {% endif %}
     cookie SERVERID insert indirect
 {% for server in groups.webservers %}
-    server simple-server{{ loop.index }} {{ server }}:{{ nginx_port }} cookie simple-server{{ loop.index }} check
+    server simple-server{{ loop.index }} {{ server }}:{{ nginx_port }} cookie simple-server{{ loop.index }} check inter 15s
 {% endfor %}
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }


### PR DESCRIPTION
**Story card:** [ch5835](https://app.shortcut.com/simpledotorg/story/5835/ethiopia-haproxy-health-checks-fail-intermittently)

## Because

We are seeing a lot of failing health checks which don't point to an underlying issue. The default rate is 2 seconds, we can relax it a little bit.

## This addresses

Increases the health check rate to once every 15 seconds.
