### PR TITLE
Install sidekiq from deployment

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -86,7 +86,7 @@ Populate the new files you've created with appropriate configurations. Use any o
 get started, and then customize for your new environment. Notably, be sure to update the following parameters:
 
 * Environment name in the `group_vars` file
-* IP addresses in the `hosts` file
+* IP addresses in the `hosts` file. Sidekiq hosts should be added under the `[sidekiq]` group.
 * Domain names in the `.env` and `simple.org-` Nginx files
 * SSH keys in the `ssh_keys` directory
 * Environment variables in the `.env` file

--- a/ansible/conf-update.yml
+++ b/ansible/conf-update.yml
@@ -3,3 +3,6 @@
   roles:
     - { role: ssh, tags: ['ssh'] }
     - { role: simple-server, tags: ['simple-server'] }
+- hosts: sidekiq
+  roles:
+    - { role: sidekiq, tags: ['sidekiq'] }

--- a/ansible/hosts.bangladesh-demo
+++ b/ansible/hosts.bangladesh-demo
@@ -2,6 +2,9 @@
 ec2-13-233-8-130.ap-south-1.compute.amazonaws.com
 ec2-15-207-249-148.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-15-207-249-148.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.bangladesh-production
+++ b/ansible/hosts.bangladesh-production
@@ -3,6 +3,9 @@ ec2-13-232-216-97.ap-south-1.compute.amazonaws.com
 ec2-13-234-48-121.ap-south-1.compute.amazonaws.com
 ec2-13-232-171-227.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-13-232-171-227.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.performance-primary
+++ b/ansible/hosts.performance-primary
@@ -1,6 +1,9 @@
 [simple]
 13.234.136.191
 
+[sidekiq]
+13.234.136.191
+
 [rails:children]
 simple
 

--- a/ansible/hosts.production
+++ b/ansible/hosts.production
@@ -6,6 +6,9 @@ ec2-65-2-69-104.ap-south-1.compute.amazonaws.com
 ec2-13-126-110-54.ap-south-1.compute.amazonaws.com
 ec2-15-206-165-4.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-13-126-110-54.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.qa
+++ b/ansible/hosts.qa
@@ -1,6 +1,9 @@
 [simple]
 ec2-3-108-62-212.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-3-108-62-212.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.sandbox
+++ b/ansible/hosts.sandbox
@@ -2,6 +2,9 @@
 ec2-65-0-103-246.ap-south-1.compute.amazonaws.com
 ec2-13-127-222-227.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-13-127-222-227.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.security
+++ b/ansible/hosts.security
@@ -1,6 +1,9 @@
 [simple]
 ec2-13-232-139-143.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-13-232-139-143.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.sri-lanka-demo
+++ b/ansible/hosts.sri-lanka-demo
@@ -2,6 +2,9 @@
 ec2-15-206-165-200.ap-south-1.compute.amazonaws.com
 ec2-15-206-194-112.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-15-206-194-112.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.sri-lanka-production
+++ b/ansible/hosts.sri-lanka-production
@@ -3,6 +3,9 @@ ec2-13-232-113-147.ap-south-1.compute.amazonaws.com
 ec2-13-233-251-139.ap-south-1.compute.amazonaws.com
 ec2-3-7-252-193.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-3-7-252-193.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -4,9 +4,6 @@ ec2-3-110-48-223.ap-south-1.compute.amazonaws.com
 [sidekiq]
 ec2-3-110-48-223.ap-south-1.compute.amazonaws.com
 
-[sidekiq]
-ec2-13-127-111-26.ap-south-1.compute.amazonaws.com
-
 [rails:children]
 simple
 

--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -1,6 +1,9 @@
 [simple]
 ec2-13-127-111-26.ap-south-1.compute.amazonaws.com
 
+[sidekiq]
+ec2-13-127-111-26.ap-south-1.compute.amazonaws.com
+
 [rails:children]
 simple
 

--- a/ansible/roles/sidekiq/tasks/main.yml
+++ b/ansible/roles/sidekiq/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: ensure user level systemd dir exists
+  file:
+    path: /home/{{ deploy_user }}/.config/systemd/user/
+    state: directory
+
+- name: copy sidekiq parent process systemd file
+  template:
+    src: config/systemd/user/sidekiq.service
+    dest: /home/{{ deploy_user }}/.config/systemd/user/sidekiq.service
+
+- name: copy sidekiq systemd file
+  template:
+    src: config/systemd/user/sidekiq@.service
+    dest: /home/{{ deploy_user }}/.config/systemd/user/sidekiq@.service
+
+- name: enable sidekiq
+  systemd:
+    name: sidekiq.service
+    enabled: yes
+    scope: user
+
+- name: restart sidekiq
+  systemd:
+    name: sidekiq.service
+    state: restarted
+    scope: user
+  tags: restart-sidekiq

--- a/ansible/roles/sidekiq/tasks/main.yml
+++ b/ansible/roles/sidekiq/tasks/main.yml
@@ -1,24 +1,32 @@
 ---
 - name: ensure user level systemd dir exists
   file:
-    path: /home/{{ deploy_user }}/.config/systemd/user/
+    path: /home/deploy/.config/systemd/user/
     state: directory
+  become: true
+  become_user: deploy
 
 - name: copy sidekiq parent process systemd file
   template:
     src: config/systemd/user/sidekiq.service
-    dest: /home/{{ deploy_user }}/.config/systemd/user/sidekiq.service
+    dest: /home/deploy/.config/systemd/user/sidekiq.service
+  become: true
+  become_user: deploy
 
 - name: copy sidekiq systemd file
   template:
     src: config/systemd/user/sidekiq@.service
-    dest: /home/{{ deploy_user }}/.config/systemd/user/sidekiq@.service
+    dest: /home/deploy/.config/systemd/user/sidekiq@.service
+  become: true
+  become_user: deploy
 
 - name: enable sidekiq
   systemd:
     name: sidekiq.service
     enabled: yes
     scope: user
+  become: true
+  become_user: deploy
 
 - name: restart sidekiq
   systemd:
@@ -26,3 +34,5 @@
     state: restarted
     scope: user
   tags: restart-sidekiq
+  become: true
+  become_user: deploy

--- a/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq.service
+++ b/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sidekiq workers
+After=syslog.target network.target
+{% for i in range(sidekiq_processes) %}
+Wants=sidekiq@{{ i }}.service
+{% endfor %}
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+ExecReload=/bin/kill -TSTP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
+RemainAfterExit=true
+
+[Install]
+WantedBy=default.target

--- a/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
+++ b/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Sidekiq for simple-server {{ deploy_env }}
+After=syslog.target network.target
+
+# restarts/stops with sidekiq
+PartOf=sidekiq.service
+
+[Service]
+Type=simple
+Environment=RAILS_ENV=production
+WorkingDirectory=/home/deploy/apps/simple-server/current
+ExecStart=/home/deploy/.rbenv/shims/bundle exec sidekiq -e production
+ExecReload=/bin/kill -TSTP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
+SyslogIdentifier=sidekiq
+
+# restart & stop send TERM to main process, wait up to 30 seconds, then KILL if still running
+KillMode=mixed
+TimeoutStopSec=30
+# restart on non-zero exit or other failure after 5 seconds
+Restart=on-failure
+RestartSec=5
+# don't create a new systemd.slice per instance
+Slice=system.slice
+
+[Install]
+WantedBy=default.target

--- a/ansible/roles/sidekiq/vars/main.yml
+++ b/ansible/roles/sidekiq/vars/main.yml
@@ -1,0 +1,2 @@
+---
+sidekiq_processes: 4


### PR DESCRIPTION
**Story card:** -

## Because

Our app installation is currently split between `deployment` and `simple-server` due to sidekiq. It is required to run a `cap sidekiq:install` from simple-server when setting up an new env. We should take care of it from the deployment repo.

## This addresses

Adds a sidekiq installation role to ansible scripts. This has been tested while upgrading ubuntu on sandbox.

Accompanying simple-server PR https://github.com/simpledotorg/simple-server/pull/3159