### PR TITLE
Upgrade IHCI staging ubuntu

### DIFF
--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -1,5 +1,8 @@
 [simple]
-ec2-13-127-111-26.ap-south-1.compute.amazonaws.com
+ec2-3-110-48-223.ap-south-1.compute.amazonaws.com
+
+[sidekiq]
+ec2-3-110-48-223.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple


### PR DESCRIPTION
**Story card:** [ch3174](https://app.shortcut.com/simpledotorg/story/3174/upgrade-ubuntu-to-a-newer-lts-release-current-version-eol-april-2021?vc_group_by=day&ct_workflow=all&cf_workflow=500000005)

Updates IHCI staging host IP