### PR TITLE
Upgrade ubuntu in BD and IHCI production

### DIFF
--- a/ansible/hosts.bangladesh-demo
+++ b/ansible/hosts.bangladesh-demo
@@ -1,9 +1,9 @@
 [simple]
-ec2-13-233-8-130.ap-south-1.compute.amazonaws.com
-ec2-15-207-249-148.ap-south-1.compute.amazonaws.com
+ec2-13-232-175-77.ap-south-1.compute.amazonaws.com
+ec2-15-206-203-213.ap-south-1.compute.amazonaws.com
 
 [sidekiq]
-ec2-15-207-249-148.ap-south-1.compute.amazonaws.com
+ec2-15-206-203-213.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/ansible/hosts.bangladesh-production
+++ b/ansible/hosts.bangladesh-production
@@ -1,10 +1,10 @@
 [simple]
-ec2-13-232-216-97.ap-south-1.compute.amazonaws.com
-ec2-13-234-48-121.ap-south-1.compute.amazonaws.com
-ec2-13-232-171-227.ap-south-1.compute.amazonaws.com
+ec2-13-235-84-237.ap-south-1.compute.amazonaws.com
+ec2-3-110-236-106.ap-south-1.compute.amazonaws.com
+ec2-65-0-66-193.ap-south-1.compute.amazonaws.com
 
 [sidekiq]
-ec2-13-232-171-227.ap-south-1.compute.amazonaws.com
+ec2-65-0-66-193.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/ansible/hosts.production
+++ b/ansible/hosts.production
@@ -1,13 +1,13 @@
 [simple]
-ec2-65-2-153-170.ap-south-1.compute.amazonaws.com
-ec2-52-66-238-198.ap-south-1.compute.amazonaws.com
-ec2-65-0-99-61.ap-south-1.compute.amazonaws.com
-ec2-65-2-69-104.ap-south-1.compute.amazonaws.com
-ec2-13-126-110-54.ap-south-1.compute.amazonaws.com
-ec2-15-206-165-4.ap-south-1.compute.amazonaws.com
+ec2-13-127-223-87.ap-south-1.compute.amazonaws.com
+ec2-65-1-110-218.ap-south-1.compute.amazonaws.com
+ec2-13-232-212-55.ap-south-1.compute.amazonaws.com
+ec2-3-110-217-131.ap-south-1.compute.amazonaws.com
+ec2-13-232-144-191.ap-south-1.compute.amazonaws.com
+ec2-13-235-67-15.ap-south-1.compute.amazonaws.com
 
 [sidekiq]
-ec2-13-126-110-54.ap-south-1.compute.amazonaws.com
+ec2-13-235-67-15.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/terraform/bangladesh/main.tf
+++ b/terraform/bangladesh/main.tf
@@ -132,8 +132,8 @@ module "simple_server_bangladesh_production" {
   deployment_name               = "bangladesh-production"
   database_vpc_id               = module.simple_networking.database_vpc_id
   database_subnet_group_name    = module.simple_networking.database_subnet_group_name
-  ec2_instance_type             = "t2.medium"
-  ec2_ubuntu_version            = "16.04"
+  ec2_instance_type             = "t3.xlarge"
+  ec2_ubuntu_version            = "20.04"
   database_username             = var.bangladesh_database_username
   database_password             = var.bangladesh_database_password
   instance_security_groups      = module.simple_networking.instance_security_groups
@@ -158,7 +158,7 @@ module "simple_server_bangladesh_staging" {
   database_vpc_id               = module.simple_networking.database_vpc_id
   database_subnet_group_name    = module.simple_networking.database_subnet_group_name
   ec2_instance_type             = "t2.medium"
-  ec2_ubuntu_version            = "16.04"
+  ec2_ubuntu_version            = "20.04"
   database_username             = var.bangladesh_staging_database_username
   database_password             = var.bangladesh_staging_database_password
   instance_security_groups      = module.simple_networking.instance_security_groups


### PR DESCRIPTION
**Story card:** [ch3174](https://app.shortcut.com/simpledotorg/story/3174/upgrade-ubuntu-to-a-newer-lts-release-current-version-eol-april-2021)

Updates host IPs that were changed during the ubuntu 20 upgrade