### PR TITLE
Fix bundle path for standalone

### DIFF
--- a/standalone/ansible/roles/simple-server/hooks/after_symlink.yml
+++ b/standalone/ansible/roles/simple-server/hooks/after_symlink.yml
@@ -1,11 +1,7 @@
 # Ansistrano after symlink tasks
 ---
-- name: Show the paths
-  command: echo {{ ansistrano_release_path }} && echo {{ ansistrano_shared_path }}
-  working_dir: "{{ ansistrano_shared_path }}"
-- name: Fix bundler path
-  command: "sed -i \"s#{{ ansistrano_releases_path }}/[0-9]\+/#{{ ansistrano_shared_path }}/#g\" .bundle/plugin/index"
-  working_dir: "{{ ansistrano_shared_path }}"
+- name: Fix bundler path for bootboot
+  command: sed -i "s#{{ ansistrano_releases_path }}/[0-9,Z]\+/#{{ ansistrano_shared_path }}/#g" {{ ansistrano_shared_path }}/.bundle/plugin/index
 - name: Install required gems
   bundler:
     chdir: "{{ ansistrano_release_path.stdout }}"

--- a/standalone/ansible/roles/simple-server/hooks/after_symlink.yml
+++ b/standalone/ansible/roles/simple-server/hooks/after_symlink.yml
@@ -1,5 +1,11 @@
 # Ansistrano after symlink tasks
 ---
+- name: Show the paths
+  command: echo {{ ansistrano_release_path }} && echo {{ ansistrano_shared_path }}
+  working_dir: "{{ ansistrano_shared_path }}"
+- name: Fix bundler path
+  command: "sed -i \"s#{{ ansistrano_releases_path }}/[0-9]\+/#{{ ansistrano_shared_path }}/#g\" .bundle/plugin/index"
+  working_dir: "{{ ansistrano_shared_path }}"
 - name: Install required gems
   bundler:
     chdir: "{{ ansistrano_release_path.stdout }}"


### PR DESCRIPTION
**Story card:** [ch6351](https://app.shortcut.com/simpledotorg/story/6351/setup-dual-dependency-approach-to-prepare-for-rails-6-and-beyond)

## Because

Bootboot has a tough time in our standalone deployment environment because it configure's bundler to look for our Gemfile in an absolute release path. This release path changes with every release, of course. 

## This addresses

Updates bundler's config to look for the Gemfile in the more permanent "shared" directory of ansistrano.

Note: Ansistrano tacks on a "Z" to our release directories (lol), so this sed expression is _slightly_ different from our [capistrano fix](https://github.com/simpledotorg/simple-server/pull/3270).

This PR is a follow-up to
* https://github.com/simpledotorg/simple-server/pull/3270
* https://github.com/simpledotorg/simple-server/pull/3272
