### PR TITLE
Actually fix the collection install command

### DIFF
--- a/standalone/Makefile
+++ b/standalone/Makefile
@@ -28,7 +28,7 @@ help: ##@Miscellaneous Show this help.
 
 init: ##@Setup Install ansible plugins and dependencies
 	ansible-galaxy install -r ansible/requirements.yml
-	ansible-galaxy collection install -r requirements.yml -p ./
+	ansible-galaxy collection install -r ansible/requirements.yml -p ./
 	pip install jmespath
 
 all: ##@Setup Install simple-server on hosts. Runs the all.yml playbook


### PR DESCRIPTION
**Story card:** none

## Because

[Semaphore is using ansible 2.9 for the standalone envs](https://docs.ansible.com/ansible/2.9/user_guide/collections_using.html#installing-collections)
