### PR TITLE
Set MALLOC_ARENA_MAX for sidekiq processes

### DIFF
--- a/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
+++ b/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
@@ -8,6 +8,7 @@ PartOf=sidekiq.service
 [Service]
 Type=simple
 Environment=RAILS_ENV=production
+Environment=MALLOC_ARENA_MAX=2
 WorkingDirectory=/home/deploy/apps/simple-server/current
 ExecStart=/home/deploy/.rbenv/shims/bundle exec sidekiq -e production
 ExecReload=/bin/kill -TSTP $MAINPID


### PR DESCRIPTION
**Story card:** [ch8182](https://app.shortcut.com/simpledotorg/story/8182/sidekiq-downtime-issues)

## Because

We've been seeing memory bloat (and a potential memory leak) on our sidekiq servers. There's plenty of material that suggests setting `MALLOC_ARENA_MAX=2` when running sidekiq to reduce memory usage (as a default, even). 
- https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
- https://devcenter.heroku.com/changelog-items/1683
- https://bugs.ruby-lang.org/issues/14759

There's a detailed explanation in this post: https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html

## This addresses

Sets `MALLOC_ARENA_MAX` in sidekiq config. (This will auto deploy when the PR is merged)
