### PR TITLE
Use jemalloc with sidekiq

### DIFF
--- a/ansible/roles/sidekiq/tasks/main.yml
+++ b/ansible/roles/sidekiq/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: install jemalloc
+  apt:
+    pkg: libjemalloc-dev=5.2.1-1ubuntu1
+    state: present
+  become: true
+
 - name: ensure user level systemd dir exists
   file:
     path: /home/deploy/.config/systemd/user/

--- a/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
+++ b/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
@@ -8,7 +8,8 @@ PartOf=sidekiq.service
 [Service]
 Type=simple
 Environment=RAILS_ENV=production
-Environment=MALLOC_ARENA_MAX=2
+Environment=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+Environment=MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0"
 WorkingDirectory=/home/deploy/apps/simple-server/current
 ExecStart=/home/deploy/.rbenv/shims/bundle exec sidekiq -e production
 ExecReload=/bin/kill -TSTP $MAINPID

--- a/standalone/ansible/roles/sidekiq/tasks/main.yml
+++ b/standalone/ansible/roles/sidekiq/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: install jemalloc
+  apt:
+    pkg: libjemalloc-dev=5.2.1-1ubuntu1
+    state: present
+  become: true
+
 - name: ensure user level systemd dir exists
   file:
     path: /home/{{ deploy_user }}/.config/systemd/user/

--- a/standalone/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
+++ b/standalone/ansible/roles/sidekiq/templates/config/systemd/user/sidekiq@.service
@@ -8,6 +8,8 @@ PartOf=sidekiq.service
 [Service]
 Type=simple
 Environment=RAILS_ENV=production
+Environment=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+Environment=MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0"
 WorkingDirectory=/home/deploy/apps/simple-server/current
 ExecStart=/home/deploy/.rbenv/shims/bundle exec sidekiq -e production
 ExecReload=/bin/kill -TSTP $MAINPID


### PR DESCRIPTION
**Story card:** [ch8182](https://app.shortcut.com/simpledotorg/story/8182/sidekiq-downtime-issues)

## Because

Using malloc with sidekiq causes memory fragmentation as discussed [here](https://brandonhilkert.com/blog/reducing-sidekiq-memory-usage-with-jemalloc) and elsewhere. jemalloc is an alternative memory allocator that does not have this problem and should stop the memory leaks we've been seeing.

As tested on IHCI production (last process in picture here is running jemalloc)
![image](https://user-images.githubusercontent.com/16774200/167571314-9cab32fd-8049-4821-98b4-93d5fce943ec.png)

## This addresses

Sets up jemalloc on sidekiq servers. Removes `MALLOC_ARENA_MAX` added in https://github.com/simpledotorg/deployment/pull/423 since it jemalloc doesn't do anything with it.
