### PR TITLE
Update semaphore secret names

### DIFF
--- a/.semaphore/update_bangladesh_demo_config.yml
+++ b/.semaphore/update_bangladesh_demo_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.bangladesh-demo
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_bangladesh_production_config.yml
+++ b/.semaphore/update_bangladesh_production_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.bangladesh-production
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_ethiopia_demo_config.yml
+++ b/.semaphore/update_ethiopia_demo_config.yml
@@ -11,7 +11,7 @@ blocks:
             - make init
             - make update-app-config hosts=ethiopia/demo password_file=~/.ansible/vault_password_et
       secrets:
-        - name: ansible ethiopia
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_ethiopia_production_config.yml
+++ b/.semaphore/update_ethiopia_production_config.yml
@@ -11,7 +11,7 @@ blocks:
             - make init
             - make update-app-config hosts=ethiopia/production password_file=~/.ansible/vault_password_et
       secrets:
-        - name: ansible ethiopia
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_india_demo_config.yml
+++ b/.semaphore/update_india_demo_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.staging
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_india_production_config.yml
+++ b/.semaphore/update_india_production_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.production
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_performance_primary_config.yml
+++ b/.semaphore/update_performance_primary_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.performance-primary
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_qa_config.yml
+++ b/.semaphore/update_qa_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.qa
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_sandbox_config.yml
+++ b/.semaphore/update_sandbox_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.sandbox
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_sri_lanka_demo_config.yml
+++ b/.semaphore/update_sri_lanka_demo_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.sri-lanka-demo
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:

--- a/.semaphore/update_sri_lanka_production_config.yml
+++ b/.semaphore/update_sri_lanka_production_config.yml
@@ -10,7 +10,7 @@ blocks:
             - cd ansible
             - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v --vault-id ~/.ansible/password_file conf-update.yml -i hosts.sri-lanka-production
       secrets:
-        - name: ansible
+        - name: ansible-vault-passwords
         - name: semaphore-deploy-key
       prologue:
         commands:


### PR DESCRIPTION
**Story card:** N/A

## Because

I updated the organization of secrets in Semaphore, and our configs reference the secret names.

## This addresses

Update the ansible vault related secrets to `ansible-vault-passwords`
