### PR TITLE
Upgrade postgres version to 14.2

### DIFF
--- a/ansible/hosts.qa
+++ b/ansible/hosts.qa
@@ -1,8 +1,8 @@
 [simple]
-ec2-3-108-62-212.ap-south-1.compute.amazonaws.com
+ec2-3-111-217-201.ap-south-1.compute.amazonaws.com
 
 [sidekiq]
-ec2-3-108-62-212.ap-south-1.compute.amazonaws.com
+ec2-3-111-217-201.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/ansible/hosts.sandbox
+++ b/ansible/hosts.sandbox
@@ -1,5 +1,5 @@
 [simple]
-ec2-52-66-104-164.ap-south-1.compute.amazonaws.com
+ec2-3-109-144-155.ap-south-1.compute.amazonaws.com
 ec2-3-108-193-51.ap-south-1.compute.amazonaws.com
 
 [sidekiq]

--- a/ansible/hosts.security
+++ b/ansible/hosts.security
@@ -1,8 +1,8 @@
 [simple]
-ec2-13-232-139-143.ap-south-1.compute.amazonaws.com
+ec2-13-233-130-252.ap-south-1.compute.amazonaws.com
 
 [sidekiq]
-ec2-13-232-139-143.ap-south-1.compute.amazonaws.com
+ec2-13-233-130-252.ap-south-1.compute.amazonaws.com
 
 [rails:children]
 simple

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,8 +1,0 @@
-{
-  "version": 4,
-  "terraform_version": "1.1.9",
-  "serial": 1,
-  "lineage": "1708a44f-b343-df7d-fffe-4453d814f304",
-  "outputs": {},
-  "resources": []
-}

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,0 +1,8 @@
+{
+  "version": 4,
+  "terraform_version": "1.1.9",
+  "serial": 1,
+  "lineage": "1708a44f-b343-df7d-fffe-4453d814f304",
+  "outputs": {},
+  "resources": []
+}

--- a/terraform/development/.terraform.lock.hcl
+++ b/terraform/development/.terraform.lock.hcl
@@ -1,27 +1,9 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.2.0"
-  hashes = [
-    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
-    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
-    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
-    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
-    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
-    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
-    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
-    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
-    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
-    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
-    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
-    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.9.0"
-  constraints = "~> 4.9.0"
+  constraints = ">= 4.8.0, ~> 4.9.0"
   hashes = [
     "h1:OWIIlbMZl/iQ8qR1U7Co3sGjNHL1HJtgNRnnV1kXNuI=",
     "zh:084b83aef3335ad4f5e4b8323c6fe43c1ff55e17a7647c6a5cad6af519f72b42",
@@ -80,7 +62,8 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.1"
+  version     = "3.1.1"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -145,9 +145,10 @@ module "simple_server_sandbox" {
   deployment_name               = "development-sandbox"
   database_vpc_id               = module.simple_networking.database_vpc_id
   database_subnet_group_name    = module.simple_networking.database_subnet_group_name
+  database_postgres_version     = "14.2"
   ec2_instance_type             = "t2.2xlarge"
   ec2_ubuntu_version            = "20.04"
-  database_instance_type        = "db.r4.xlarge"
+  database_instance_type        = "db.r5.xlarge"
   server_count                  = 1
   sidekiq_server_count          = 1
   database_username             = var.sandbox_database_username
@@ -198,6 +199,8 @@ module "simple_server_qa" {
   ec2_ubuntu_version            = "20.04"
   database_username             = var.qa_database_username
   database_password             = var.qa_database_password
+  database_postgres_version     = "14.2"
+  database_instance_type        = "db.t3.medium"
   instance_security_groups      = module.simple_networking.instance_security_groups
   aws_key_name                  = module.simple_aws_key_pair.simple_aws_key_name
   server_vpc_id                 = module.simple_networking.server_vpc_id
@@ -245,6 +248,8 @@ module "simple_server_security" {
   ec2_ubuntu_version            = "20.04"
   database_username             = var.security_database_username
   database_password             = var.security_database_password
+  database_instance_type        = "db.t3.medium"
+  database_postgres_version     = "14.2"
   instance_security_groups      = module.simple_networking.instance_security_groups
   aws_key_name                  = module.simple_aws_key_pair.simple_aws_key_name
   server_vpc_id                 = module.simple_networking.server_vpc_id


### PR DESCRIPTION
**Story card:** [sc-8306](https://app.shortcut.com/simpledotorg/story/8306/upgrade-postgres-to-14-on-non-prod-envs)

Upgrades Postgres to 14.2 for the dev environments (QA, SBX, Security)
Adds the new server addresses