### PR TITLE
Increase sidekiq volume size on AWS

### DIFF
--- a/terraform/modules/simple_server/instances.tf
+++ b/terraform/modules/simple_server/instances.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "ec2_sidekiq_server" {
   monitoring                  = true
 
   root_block_device {
-    volume_size = var.ec2_volume_size
+    volume_size = var.ec2_sidekiq_volume_size
   }
 
   tags = {

--- a/terraform/modules/simple_server/variables.tf
+++ b/terraform/modules/simple_server/variables.tf
@@ -20,6 +20,12 @@ variable "ec2_volume_size" {
   default     = "30"
 }
 
+variable "ec2_sidekiq_volume_size" {
+  description = "The disk size on the root block device for sidekiq servers"
+  type        = string
+  default     = "100"
+}
+
 variable "server_count" {
   description = "The number of instance for ec2 servers"
   type        = number


### PR DESCRIPTION
**Story card:** [ch8741](https://app.shortcut.com/simpledotorg/story/8741/increase-sidekiq-volume-size-on-bd-development-sri-lanka-manually)

## Because

We provision 30G disk for the sidekiq server. This is a bit low since audit logs get generated on this instance and it has run out of storage a few times in the past.

## This addresses

Increase sidekiq instance's disk size. Changes in these PR have already been `apply`-ed.
