### PR TITLE
Turn on query logs in IHCI RDS

### DIFF
--- a/terraform/modules/simple_server/databases.tf
+++ b/terraform/modules/simple_server/databases.tf
@@ -17,6 +17,16 @@ resource "aws_db_parameter_group" "simple-database-parameter-group" {
     name  = "max_parallel_workers_per_gather"
     value = var.database_max_parallel_workers_per_gather
   }
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "100"
+  }
+
+  parameter {
+    name  = "rds.log_retention_period"
+    value = "4320"
+  }
 }
 
 resource "aws_db_instance" "simple-database" {


### PR DESCRIPTION
**Story card:** -

## Because

PG query logs are helpful for profiling and doing post-mortems and we should keep a few days worth of logs around by default.

## This addresses

Turn on query logs in IHCI that are > 100ms, keep logs around for 3 days. [Relevant AWS doc](https://aws.amazon.com/premiumsupport/knowledge-center/rds-postgresql-query-logging/)
