### PR TITLE
Bump EC2 CPU alert threshold 

### DIFF
--- a/terraform/modules/simple_server/cloudwatch.tf
+++ b/terraform/modules/simple_server/cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "average_webserver_cpu" {
   namespace                 = "AWS/EC2"
   period                    = "300"
   statistic                 = "Average"
-  threshold                 = "65"
+  threshold                 = "75"
   alarm_actions             = [var.cloudwatch_alerts_sns_arn]
   ok_actions                = [var.cloudwatch_alerts_sns_arn]
   insufficient_data_actions = [var.cloudwatch_alerts_sns_arn]
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_cpu" {
   namespace                 = "AWS/EC2"
   period                    = "60"
   statistic                 = "Average"
-  threshold                 = "65"
+  threshold                 = "75"
   alarm_actions             = [var.cloudwatch_alerts_sns_arn]
   ok_actions                = [var.cloudwatch_alerts_sns_arn]
   insufficient_data_actions = [var.cloudwatch_alerts_sns_arn]


### PR DESCRIPTION
**Story card:** -

## Because

The current CPU alert threshold on ec2 instances doesn't need any action at 65%.

## This addresses

Increases the alert threshold to 75%.
