### PR TITLE
Update sandbox aws rds postgres version to 14.6

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -192,7 +192,7 @@ module "simple_server_sandbox" {
   deployment_name               = "development-sandbox"
   database_vpc_id               = module.simple_networking.database_vpc_id
   database_subnet_group_name    = module.simple_networking.database_subnet_group_name
-  database_postgres_version     = "14.2"
+  database_postgres_version     = "14.6"
   ec2_instance_type             = "t2.2xlarge"
   ec2_ubuntu_version            = "20.04"
   database_instance_type        = "db.r5.xlarge"


### PR DESCRIPTION
**Story card:** [9993](https://app.shortcut.com/simpledotorg/story/9993)

## Because

AWS is deprecating RDS Postgres version 14.2
