### PR TITLE
Add a security rule for S3 buckets

### DIFF
--- a/terraform/modules/simple_s3/main.tf
+++ b/terraform/modules/simple_s3/main.tf
@@ -39,3 +39,11 @@ output "user_secret_key" {
   sensitive = true
 }
 
+resource "aws_s3_bucket_public_access_block" "block_logs_public_access" {
+  bucket = aws_s3_bucket.logs_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
**Story card:** [ch9984](https://app.shortcut.com/simpledotorg/story/9984/s3-bucket-misconfigurations)

## Because

Our logs S3 buckets allow public items to be added. We don't need logs to be public and this was flagged in KPMG's security audit.

## This addresses

Adds a security rule to make items in the logs S3 bucket private by default.
