### PR TITLE
Update Sri Lanka production Postgres version to 14.6

### DIFF
--- a/terraform/sri-lanka/main.tf
+++ b/terraform/sri-lanka/main.tf
@@ -166,7 +166,7 @@ module "simple_server_sri_lanka_production" {
   database_vpc_id               = module.simple_networking.database_vpc_id
   database_subnet_group_name    = module.simple_networking.database_subnet_group_name
   ec2_instance_type             = "t2.medium"
-  database_postgres_version     = "14.2"
+  database_postgres_version     = "14.6"
   database_instance_type        = "db.t3.medium"
   database_replica_instance_type = "db.t3.medium"
   ec2_ubuntu_version            = "20.04"


### PR DESCRIPTION
**Story card:** [9998](https://app.shortcut.com/simpledotorg/story/9998)

## Because

AWS is deprecating Postgres version 14.2. All the RDS Postgres instances should be updated to version 14.5 by March 20, 2023

