### PR TITLE
Upgrade India postgres to 14.6

### DIFF
--- a/terraform/india/main.tf
+++ b/terraform/india/main.tf
@@ -163,7 +163,7 @@ output "s3_logs_bucket_name" {
 module "simple_server_india_production" {
   source                                   = "../modules/simple_server"
   deployment_name                          = "india-production"
-  database_postgres_version                = "14.2"
+  database_postgres_version                = "14.6"
   database_custom_param_group              = true
   database_max_parallel_workers_per_gather = 4
   database_random_page_cost                = 1

--- a/terraform/modules/simple_server/databases.tf
+++ b/terraform/modules/simple_server/databases.tf
@@ -32,6 +32,11 @@ resource "aws_db_parameter_group" "simple-database-parameter-group" {
     name         = "hot_standby_feedback"
     value        = "1"
   }
+
+  parameter {
+    name  = "statement_timeout"
+    value = "86400000"
+  }
 }
 
 resource "aws_db_instance" "simple-database" {


### PR DESCRIPTION
**Story card:** [9996](https://app.shortcut.com/simpledotorg/story/9996)

## Because

AWS is deprecating Postgres version 14.2. All the RDS Postgres instances should be updated to version 14.5 by March 20, 2023
