### PR TITLE
Remove passenger headers from responses

### DIFF
--- a/ansible/roles/passenger/files/etc/nginx/nginx.conf
+++ b/ansible/roles/passenger/files/etc/nginx/nginx.conf
@@ -62,6 +62,8 @@ http {
   passenger_min_instances 8;
   passenger_pool_idle_time 120;
   passenger_show_version_in_header off;
+  more_clear_headers Server;
+  more_clear_headers X-Powered-By;
 
   ##
   # Virtual Host Configs


### PR DESCRIPTION
**Story card:** [ch-9986](https://app.shortcut.com/simpledotorg/story/9986/information-disclosure-in-http-response-headers?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

We expose passenger details in response headers, which is a potential source for fingerprinting the simple-server stack. [owasp ref](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.html).


## This addresses

Removes the `X-Powered-By` and `Server` headers from the response. Headers before/after:
<img width="951" alt="image" src="https://github.com/simpledotorg/deployment/assets/16774200/3f80400c-2efa-435e-87b8-1e0e3b7b29ea">

- [ ] Run `ansible-playbook -v --vault-id ~/.vault_password provision.yml -i hosts.staging` for all hosts