### PR TITLE
Update ubuntu 20.04 ami id

### DIFF
--- a/terraform/modules/simple_server/aws_ami.tf
+++ b/terraform/modules/simple_server/aws_ami.tf
@@ -1,9 +1,9 @@
 data "aws_ami" "ubuntu" {
   //  ami-0c28d7c6dd94fb3a7 is Canonical Community Ubuntu 16.04 LTS
-  //  ami-0c1a7f89451184c8b is Canonical Community Ubuntu 20.04 LTS
+  //  ami-08e5424edfe926b43 is Canonical Community Ubuntu 20.04 LTS
   filter {
-    name = "image-id"
-    values = var.ec2_ubuntu_version == "16.04" ? ["ami-0c28d7c6dd94fb3a7"] : ["ami-0c1a7f89451184c8b"] # Defaults to Ubuntu 20.04
+    name   = "image-id"
+    values = var.ec2_ubuntu_version == "16.04" ? ["ami-0c28d7c6dd94fb3a7"] : ["ami-08e5424edfe926b43"] # Defaults to Ubuntu 20.04
   }
 
   owners = ["099720109477"] # Use official Canonical Ubuntu AMIs

--- a/terraform/modules/simple_server/instances.tf
+++ b/terraform/modules/simple_server/instances.tf
@@ -14,6 +14,10 @@ resource "aws_instance" "ec2_simple_server" {
   tags = {
     Name = format("simple-server-%s-%03d", var.deployment_name, count.index + 1)
   }
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_instance" "ec2_sidekiq_server" {
@@ -32,6 +36,10 @@ resource "aws_instance" "ec2_sidekiq_server" {
   tags = {
     Name = format("simple-server-sidekiq-%s-%03d", var.deployment_name, count.index + 1)
   }
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_security_group" "sg_simple_server" {
@@ -48,8 +56,8 @@ resource "aws_lb_target_group" "simple_server_target_group" {
   health_check {
     port     = 443
     protocol = "HTTPS"
-    path    = "/api/v3/ping"
-    matcher = "200"
+    path     = "/api/v3/ping"
+    matcher  = "200"
   }
 }
 


### PR DESCRIPTION
Update ubuntu 20.04 ami id and add ignore ami change lifecycle to avoid recreation of instances

## Because

Ubuntu 20.04 AWS AMI is no longer available